### PR TITLE
test: add unit coverage for _json, openapi plugins, concurrency, and CLI

### DIFF
--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from django_bolt.cli import main
+
+
+def test_version_command():
+    """version prints the prefix followed by the pyproject version."""
+    with (Path(__file__).parents[2] / "pyproject.toml").open("rb") as f:
+        expected = tomllib.load(f)["project"]["version"]
+
+    result = CliRunner().invoke(main, ["version"])
+    assert result.exit_code == 0
+    assert "Django-Bolt version:" in result.output
+
+    reported = result.output.split("Django-Bolt version:", 1)[1].strip()
+    assert reported == expected
+
+
+def test_help_lists_version_command():
+    """--help exits cleanly and mentions the version subcommand."""
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "version" in result.output

--- a/python/tests/test_concurrency.py
+++ b/python/tests/test_concurrency.py
@@ -1,0 +1,44 @@
+"""Tests for sync_to_thread thread-pool execution."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from django_bolt.concurrency import sync_to_thread
+
+
+def test_returns_value():
+    """Positional args are forwarded and the return value comes back."""
+    assert asyncio.run(sync_to_thread(lambda a, b: a + b, 2, 3)) == 5
+
+
+def test_propagates_exception():
+    """Exceptions raised in the worker propagate to the caller."""
+
+    def boom():
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError):
+        asyncio.run(sync_to_thread(boom))
+
+
+def test_runs_off_calling_thread():
+    """The callable executes on a worker thread, not the caller's."""
+    caller = threading.get_ident()
+    worker = asyncio.run(sync_to_thread(threading.get_ident))
+    assert worker != caller
+
+
+def test_runs_concurrently():
+    """Blocking calls run in parallel rather than serializing on the loop."""
+    barrier = threading.Barrier(2, timeout=5)
+
+    async def main():
+        # Both calls must reach the barrier for it to release; if they ran
+        # serially the first wait() would time out and raise BrokenBarrierError.
+        await asyncio.gather(sync_to_thread(barrier.wait), sync_to_thread(barrier.wait))
+
+    asyncio.run(main())

--- a/python/tests/test_json_helpers.py
+++ b/python/tests/test_json_helpers.py
@@ -1,0 +1,125 @@
+"""Tests for the msgspec-backed JSON helpers in django_bolt._json."""
+
+from __future__ import annotations
+
+import enum
+from datetime import date, datetime, time
+from decimal import Decimal
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address
+from pathlib import Path, PurePath
+from uuid import UUID
+
+import msgspec
+import pytest
+
+from django_bolt import _json
+
+
+class Color(enum.Enum):
+    RED = "red"
+
+
+class Item(msgspec.Struct):
+    id: int
+
+
+def test_default_serializer_enum():
+    """Enum member serializes to its value."""
+    assert _json.default_serializer(Color.RED) == "red"
+
+
+def test_default_serializer_paths():
+    """Path and PurePath serialize to str()."""
+    p = Path("file.txt")
+    pp = PurePath("dir/file.txt")
+    assert _json.default_serializer(p) == str(p)
+    assert _json.default_serializer(pp) == str(pp)
+
+
+def test_default_serializer_datetimes():
+    """datetime/date/time serialize via isoformat()."""
+    dt = datetime(2020, 1, 2, 3, 4, 5)
+    d = date(2020, 1, 2)
+    t = time(3, 4, 5)
+    assert _json.default_serializer(dt) == dt.isoformat()
+    assert _json.default_serializer(d) == d.isoformat()
+    assert _json.default_serializer(t) == t.isoformat()
+
+
+def test_default_serializer_decimal_integral():
+    """Decimal with non-negative exponent becomes an int."""
+    result = _json.default_serializer(Decimal("5"))
+    assert result == 5
+    assert type(result) is int
+
+
+def test_default_serializer_decimal_fractional():
+    """Decimal with fractional part becomes a float."""
+    result = _json.default_serializer(Decimal("5.5"))
+    assert result == 5.5
+    assert type(result) is float
+
+
+def test_default_serializer_ip_types():
+    """IP addresses, interfaces and networks serialize to str()."""
+    assert _json.default_serializer(IPv4Address("1.2.3.4")) == "1.2.3.4"
+    assert _json.default_serializer(IPv6Address("::1")) == "::1"
+    assert _json.default_serializer(IPv4Interface("1.2.3.4/24")) == "1.2.3.4/24"
+    assert _json.default_serializer(IPv4Network("10.0.0.0/8")) == "10.0.0.0/8"
+
+
+def test_default_serializer_uuid():
+    """UUID serializes to str()."""
+    u = UUID("12345678-1234-5678-1234-567812345678")
+    assert _json.default_serializer(u) == str(u)
+
+
+def test_default_serializer_rejects_unsupported():
+    """Unsupported types raise TypeError."""
+    with pytest.raises(TypeError):
+        _json.default_serializer(object())
+
+
+def test_encode_roundtrips_plain_dict():
+    """encode/decode round-trips a plain dict."""
+    payload = {"a": 1, "b": ["x", "y"], "c": None}
+    assert _json.decode(_json.encode(payload)) == payload
+
+
+def test_encode_uses_hook_for_path():
+    """A non-native Path in the payload is routed through the hook."""
+    p = Path("hello.txt")
+    encoded = _json.encode({"path": p})
+    assert str(p).encode() in encoded
+
+
+def test_encode_rejects_unsupported():
+    """encode raises TypeError when a value has no encoder."""
+    with pytest.raises(TypeError):
+        _json.encode({"x": object()})
+
+
+def test_encode_custom_serializer_override():
+    """A custom serializer replaces the default hook."""
+
+    class Widget:
+        pass
+
+    def serializer(value):
+        if isinstance(value, Widget):
+            return "widget"
+        raise TypeError
+
+    assert _json.encode(Widget(), serializer=serializer) == b'"widget"'
+
+
+def test_decode_typed_lenient_coercion():
+    """strict=False coerces a JSON string into the target int field."""
+    item = _json.decode_typed(b'{"id": "123"}', Item, strict=False)
+    assert item.id == 123
+
+
+def test_decode_typed_strict_rejects_coercion():
+    """strict=True rejects a string where an int is expected."""
+    with pytest.raises(msgspec.ValidationError):
+        _json.decode_typed(b'{"id": "123"}', Item, strict=True)

--- a/python/tests/test_openapi_plugins.py
+++ b/python/tests/test_openapi_plugins.py
@@ -1,0 +1,102 @@
+"""
+Tests for OpenAPI UI render plugins.
+"""
+
+from django_bolt.openapi import plugins
+from django_bolt.openapi.plugins import (
+    JsonRenderPlugin,
+    RapidocRenderPlugin,
+    RedocRenderPlugin,
+    ScalarRenderPlugin,
+    StoplightRenderPlugin,
+    SwaggerRenderPlugin,
+    YamlRenderPlugin,
+)
+
+SCHEMA = {"openapi": "3.1.0", "info": {"title": "Test API", "version": "1.0.0"}, "paths": {}}
+SCHEMA_URL = "/openapi.json"
+
+
+def test_json_render_returns_schema_dict():
+    """JSON plugin returns the schema dict unchanged."""
+    assert JsonRenderPlugin().render(SCHEMA, SCHEMA_URL) is SCHEMA
+
+
+def test_swagger_embeds_title_and_spec():
+    """Swagger inlines the spec and shows the title."""
+    html = SwaggerRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert "<title>Test API</title>" in html
+    assert '"title":"Test API"' in html
+
+
+def test_redoc_embeds_title_and_spec():
+    """Redoc inlines the spec and shows the title."""
+    html = RedocRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert "<title>Test API</title>" in html
+    assert '"title":"Test API"' in html
+
+
+def test_scalar_references_schema_url():
+    """Scalar points at the schema URL via data-url."""
+    html = ScalarRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert "Test API" in html
+    assert f'data-url="{SCHEMA_URL}"' in html
+
+
+def test_rapidoc_references_schema_url():
+    """Rapidoc points at the schema URL via spec-url."""
+    html = RapidocRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert "Test API" in html
+    assert f'spec-url="{SCHEMA_URL}"' in html
+
+
+def test_stoplight_references_schema_url():
+    """Stoplight points at the schema URL via apiDescriptionUrl."""
+    html = StoplightRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert "Test API" in html
+    assert f'apiDescriptionUrl="{SCHEMA_URL}"' in html
+
+
+def test_has_path():
+    """has_path matches configured paths only."""
+    plugin = JsonRenderPlugin(path="/custom.json")
+    assert plugin.has_path("/custom.json") is True
+    assert plugin.has_path("/nope.json") is False
+
+
+def test_has_path_multiple():
+    """Plugins with a list of default paths match each one."""
+    yaml_plugin = YamlRenderPlugin()
+    assert yaml_plugin.has_path("/openapi.yaml") is True
+    assert yaml_plugin.has_path("/openapi.yml") is True
+
+    scalar = ScalarRenderPlugin()
+    assert scalar.has_path("/scalar") is True
+    assert scalar.has_path("/") is True
+
+
+def test_scalar_options_configuration():
+    """Scalar options are encoded into the configuration script."""
+    html = ScalarRenderPlugin(options={"theme": "purple"}).render(SCHEMA, SCHEMA_URL)
+    assert 'dataset.configuration = \'{"theme":"purple"}\'' in html
+
+
+def test_custom_js_and_css_urls():
+    """Custom js_url/css_url override the CDN defaults in the output."""
+    html = SwaggerRenderPlugin(js_url="https://x/ui.js", css_url="https://x/ui.css").render(SCHEMA, SCHEMA_URL)
+    assert 'src="https://x/ui.js"' in html
+    assert 'href="https://x/ui.css"' in html
+
+
+def test_yaml_render():
+    """YAML plugin dumps the schema as YAML when PyYAML is available."""
+    out = YamlRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert "title: Test API" in out
+
+
+def test_yaml_render_fallback(monkeypatch):
+    """Without PyYAML the YAML plugin falls back to annotated JSON."""
+    monkeypatch.setattr(plugins, "yaml", None)
+    out = YamlRenderPlugin().render(SCHEMA, SCHEMA_URL)
+    assert out.startswith("# PyYAML not installed")
+    assert '"title":"Test API"' in out

--- a/python/tests/test_syntax.py
+++ b/python/tests/test_syntax.py
@@ -6,8 +6,9 @@ from typing import Annotated
 
 import msgspec
 import pytest
+from django.conf import settings
 
-from django_bolt import JSON, BoltAPI, Response, StreamingResponse
+from django_bolt import JSON, BoltAPI, Response, StreamingResponse, UploadFile
 from django_bolt.exceptions import HTTPException
 from django_bolt.param_functions import Cookie, Depends, Form, Header, Query
 from django_bolt.param_functions import File as FileParam
@@ -758,17 +759,28 @@ def test_large_file_upload_rejected_by_default(api):
         assert response.status_code in (413, 422), f"Expected 413 or 422, got {response.status_code}: {response.text}"
 
 
-def test_large_file_upload_with_increased_limit(api):
-    """Test that file uploads within the limit work correctly.
+def test_large_file_upload_with_increased_limit():
+    """Raising BOLT_MAX_UPLOAD_SIZE lets through an upload the default limit would reject."""
+    had_attr = hasattr(settings, "BOLT_MAX_UPLOAD_SIZE")
+    prev = getattr(settings, "BOLT_MAX_UPLOAD_SIZE", None)
+    settings.BOLT_MAX_UPLOAD_SIZE = 4 * 1024 * 1024
+    try:
+        api = BoltAPI()
 
-    Note: Upload size limits are now compiled into route metadata at startup.
-    The default max_upload_size is 1MB, set in middleware/compiler.py.
-    Testing dynamic BOLT_MAX_UPLOAD_SIZE changes requires server restart.
-    """
-    # This test is skipped because max_upload_size is now compiled at route registration time
-    # and cannot be changed dynamically. To test increased limits, need to configure
-    # max_upload_size in route metadata before server starts.
-    pytest.skip("Upload size limits are now compiled at route registration time (Rust implementation)")
+        @api.post("/upload")
+        async def upload(avatar: UploadFile = FileParam()):
+            return {"size": avatar.size}
+
+        content = b"x" * (2 * 1024 * 1024)
+        with TestClient(api) as test_client:
+            response = test_client.post("/upload", files={"avatar": ("big.bin", content, "application/octet-stream")})
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+        assert response.json()["size"] == len(content)
+    finally:
+        if had_attr:
+            settings.BOLT_MAX_UPLOAD_SIZE = prev
+        else:
+            delattr(settings, "BOLT_MAX_UPLOAD_SIZE")
 
 
 def test_error_responses_have_cors_headers(api):


### PR DESCRIPTION
## What

Adds direct unit tests for a few modules that had little or no dedicated coverage, and revives a test that was being skipped.

- **`_json`** — `default_serializer` type branches (Enum, Path/PurePath, datetime/date/time, Decimal int-vs-float, IP types, UUID, and unsupported → `TypeError`), `encode`/`decode` round-trips, `decode_typed` strict vs. lenient coercion, and the custom-serializer override path.
- **`openapi.plugins`** — `render()` output and `has_path()` for each render plugin (JSON/Swagger/Redoc/Scalar/Rapidoc/Stoplight/YAML), Scalar `options` serialization, custom `js_url`/`css_url` overrides, and the YAML fallback when PyYAML isn't installed.
- **`concurrency.sync_to_thread`** — positional-arg forwarding, return value, exception propagation, off-thread execution, and real parallelism (asserted with a `threading.Barrier` so it can't pass under serialized execution).
- **`cli`** — the `version` command prints the version from `pyproject.toml`.
- **`test_syntax`** — replaces `test_large_file_upload_with_increased_limit`, which was an unconditional `pytest.skip`, with a real test that raises `BOLT_MAX_UPLOAD_SIZE` and asserts an upload the default limit would reject now succeeds. Complements the existing `test_large_file_upload_rejected_by_default`.

## Why

These modules were exercised only indirectly (or not at all), so a regression in them could ship silently. The skipped upload test asserted nothing.

## Notes

Tests only — no source changes. All new tests pass locally and use the existing `TestClient` / plain-pytest patterns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

The PR does not touch the hot request path. It contains only test changes, adding coverage for JSON helpers, OpenAPI plugins, concurrency utilities, the CLI, and large-file uploads.

No production/runtime code was modified, so it introduces no hot-path overhead or unnecessary work. The upload test exercises request handling but does not change its implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->