### PR TITLE
docs(testing): cover Django's test runner, and warn on the transaction trap

### DIFF
--- a/docs/src/topics/testing.md
+++ b/docs/src/topics/testing.md
@@ -393,6 +393,64 @@ def test_article_viewset(api):
         assert response.json()["title"] == "Test Article"
 ```
 
+## Using Django's test runner
+
+Everything above uses pytest, but `manage.py test` works too — with two
+adjustments.
+
+**Django's own test client does not see Bolt routes.** `self.client` resolves
+against `ROOT_URLCONF`, and your Bolt handlers live in the Rust router, not in
+Django's URL configuration. A request for a route that exists returns 404:
+
+```python
+class Wrong(TestCase):
+    def test_slides(self):
+        response = self.client.get("/slides/")
+        assert response.status_code == 404  # not registered in ROOT_URLCONF
+```
+
+Use `TestClient` instead. It goes through the real Rust pipeline, so routing,
+middleware, and auth all behave as they do in production.
+
+**Use `TransactionTestCase`, not `TestCase`,** whenever your handlers touch the
+database. This is the same constraint as
+[`transaction=True`](#why-transactiontrue-is-required) above, for the same
+reason: `TestCase` wraps each test in a transaction it never commits, so the
+handler's connection cannot see your rows. On SQLite it is worse than an empty
+result — the write lock your test holds blocks the handler's query, and you get
+`database table is locked` surfacing as a bare 500:
+
+```python
+from django.test import TransactionTestCase
+from django_bolt.testing import TestClient
+
+from .api import api
+from .models import Slide
+
+
+class TestSlides(TransactionTestCase):
+    def test_lists_slides(self):
+        Slide.objects.create(description="hello")
+
+        with TestClient(api) as client:
+            response = client.get("/slides/")
+            assert response.status_code == 200
+            assert response.json() == [{"id": 1, "description": "hello"}]
+```
+
+Entering a `TestClient` inside an open transaction emits a
+`BoltTestClientWarning` pointing at this section. It is advisory, not an error —
+handlers that never touch the database are fine under `TestCase` — and fires at
+most once per process. Silence it with:
+
+```python
+warnings.simplefilter("ignore", BoltTestClientWarning)
+```
+
+Unlike pytest's `transaction=True`, `TransactionTestCase` truncates tables
+after each test, so the [manual cleanup](#cleaning-up-between-tests) described
+above is not needed here.
+
 ## Authenticated endpoints
 
 You don't need a login flow to test a protected route.

--- a/python/django_bolt/testing/__init__.py
+++ b/python/django_bolt/testing/__init__.py
@@ -25,12 +25,13 @@ Usage:
         assert response == "Echo: hello"
 """
 
-from django_bolt.testing.client import AsyncTestClient, TestClient
+from django_bolt.testing.client import AsyncTestClient, BoltTestClientWarning, TestClient
 from django_bolt.testing.websocket import ConnectionClosed, WebSocketTestClient
 
 __all__ = [
     "TestClient",
     "AsyncTestClient",
+    "BoltTestClientWarning",
     "WebSocketTestClient",
     "ConnectionClosed",
 ]

--- a/python/django_bolt/testing/client.py
+++ b/python/django_bolt/testing/client.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import builtins
 import contextlib
+import logging
+import warnings
 from collections.abc import Iterator
 from typing import Any
 from urllib.parse import urlsplit
@@ -23,10 +25,65 @@ from django_bolt import BoltAPI, _core
 from django_bolt._bridge import make_bound_dispatch
 from django_bolt.api import _validate_asgi_mount_conflicts, _validate_mcp_mount_conflicts
 
+logger = logging.getLogger(__name__)
+
 try:
     from django.conf import settings
+    from django.db import connections
 except ImportError:
     settings = None  # type: ignore
+    connections = None  # type: ignore
+
+
+class BoltTestClientWarning(RuntimeWarning):
+    """Advisory about a test setup that TestClient cannot serve correctly.
+
+    Its own category so it can be silenced with
+    ``warnings.simplefilter("ignore", BoltTestClientWarning)``.
+    """
+
+
+# Emitted at most once per process. The point is to explain a confusing
+# failure mode once, not to annotate every call site: a suite that mixes
+# database-free TestClient tests with a transactional marker would otherwise
+# repeat this on every one of them.
+_atomic_block_warning_emitted = False
+
+
+def _warn_if_inside_atomic_block() -> None:
+    """Warn when the entering test is holding an open transaction.
+
+    Requests run through the Rust pipeline, so handlers execute on framework
+    threads with their own database connections. A test that wraps itself in a
+    transaction — Django's ``TestCase``, or pytest-django's plain ``django_db``
+    — never commits, so those rows are invisible to the handler, and on SQLite
+    the write lock the test holds turns the handler's query into ``database
+    table is locked``. Either way the symptom is an opaque 500 with nothing
+    pointing at the cause.
+
+    Advisory only: a test whose handlers never touch the database works fine
+    inside a transaction, so this must not fail the run.
+    """
+    global _atomic_block_warning_emitted
+    if connections is None or _atomic_block_warning_emitted:
+        return
+    try:
+        open_aliases = [conn.alias for conn in connections.all(initialized_only=True) if conn.in_atomic_block]
+    except Exception as exc:  # unconfigured settings, no databases, etc.
+        logger.debug("Could not inspect database transaction state: %s", exc)
+        return
+    if not open_aliases:
+        return
+    _atomic_block_warning_emitted = True
+    warnings.warn(
+        f"TestClient entered inside an open database transaction on: {', '.join(open_aliases)}. "
+        "Handlers run on framework threads with their own database connections, so they "
+        "cannot see rows this test has created, and on SQLite the lock it holds surfaces "
+        "as an opaque 500. Use TransactionTestCase (or pytest-django's "
+        "django_db(transaction=True)) for tests whose handlers touch the database.",
+        BoltTestClientWarning,
+        stacklevel=3,
+    )
 
 
 class BoltTestTransport(httpx.BaseTransport):
@@ -451,6 +508,7 @@ class TestClient(httpx.Client):
 
     def __enter__(self):
         """Enter context manager — runs lifespan startup if configured."""
+        _warn_if_inside_atomic_block()
         if self.api._has_lifespan:
             loop = asyncio.new_event_loop()
             cm = self.api._lifespan_context(self.api)
@@ -729,6 +787,7 @@ class AsyncTestClient(httpx.AsyncClient):
 
     async def __aenter__(self):
         """Enter async context manager — runs lifespan startup if configured."""
+        _warn_if_inside_atomic_block()
         if self.api._has_lifespan:
             cm = self.api._lifespan_context(self.api)
             await cm.__aenter__()

--- a/python/tests/test_testclient_atomic_block.py
+++ b/python/tests/test_testclient_atomic_block.py
@@ -1,0 +1,105 @@
+"""
+TestClient behavior when the test wraps itself in a transaction.
+
+`TestClient` drives requests through the Rust pipeline, so handlers run on
+framework threads with their own database connections. Django's `TestCase`
+(and pytest-django's plain `django_db`) wrap each test in an uncommitted
+transaction on the *calling* thread's connection, so rows created by the test
+are invisible to those handler threads — and on SQLite the held write lock
+turns the handler's query into `database table is locked`, surfacing as an
+opaque 500.
+
+`TransactionTestCase` / `django_db(transaction=True)` commit instead, which is
+why every database-touching TestClient test in this suite uses the
+transactional variant. Nothing warned about the difference, so the failure
+mode was a 500 with no pointer to the cause (issue #276).
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import connection
+
+from django_bolt import BoltAPI
+from django_bolt.testing import TestClient
+from django_bolt.testing import client as client_module
+from django_bolt.testing.client import BoltTestClientWarning
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def reset_warning_latch(monkeypatch):
+    """The advisory fires once per process; these tests each need a fresh latch."""
+    monkeypatch.setattr(client_module, "_atomic_block_warning_emitted", False)
+
+
+def _advisories(recorded) -> list:
+    """The BoltTestClientWarnings among everything pytest recorded."""
+    return [w for w in recorded.list if issubclass(w.category, BoltTestClientWarning)]
+
+
+def _make_api() -> BoltAPI:
+    api = BoltAPI()
+
+    @api.get("/users")
+    async def list_users():
+        return User.objects.values("username")
+
+    @api.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    return api
+
+
+@pytest.mark.django_db
+def test_warns_when_entered_inside_atomic_block():
+    """A non-transactional test wraps an atomic block — handlers cannot see it."""
+    assert connection.in_atomic_block, "precondition: plain django_db is transactional"
+
+    with pytest.warns(BoltTestClientWarning, match="TransactionTestCase"), TestClient(_make_api()):
+        pass
+
+
+@pytest.mark.django_db(transaction=True)
+def test_no_warning_under_transactional_db(recwarn):
+    """The supported pattern must stay silent."""
+    assert not connection.in_atomic_block
+
+    with TestClient(_make_api()):
+        pass
+
+    assert not _advisories(recwarn)
+
+
+def test_no_warning_without_database_access(recwarn):
+    """No database involvement at all — nothing to warn about."""
+    with TestClient(_make_api()) as client:
+        assert client.get("/ping").status_code == 200
+
+    assert not _advisories(recwarn)
+
+
+@pytest.mark.django_db
+def test_warning_is_emitted_only_once_per_process(recwarn):
+    """Repeated clients must not flood a suite that mixes marker styles."""
+    with TestClient(_make_api()):
+        pass
+    assert len(_advisories(recwarn)) == 1
+
+    with TestClient(_make_api()):
+        pass
+    assert len(_advisories(recwarn)) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_handler_sees_committed_test_data():
+    """The behavior the warning steers people toward actually works."""
+    User.objects.create(username="visible-to-handler", email="v@example.com")
+
+    with TestClient(_make_api()) as client:
+        response = client.get("/users")
+        assert response.status_code == 200
+        assert [row["username"] for row in response.json()] == ["visible-to-handler"]


### PR DESCRIPTION
A `TestCase` calling `self.client.get()` returned 404, and switching to `TestClient` returned rows the test never created. Both behaviors are documented for pytest users and completely undocumented for anyone using `manage.py test` — `testing.md` mentions neither `TestCase`, `TransactionTestCase`, nor `django.test` anywhere in its 561 lines.

Fixes #276

### What actually happens

Reproduced in a minimal project (model, one Bolt route, three test styles):

| test style | result |
|---|---|
| Django test client + `TestCase` | **404** — Bolt routes live in the Rust router, not `ROOT_URLCONF` |
| `TestClient` + `TestCase` | **500** `database table is locked: core_slide` |
| `TestClient` + `TransactionTestCase` | **200**, correct test-database rows |

The 500 is the expensive one. `TestCase` wraps the test in a transaction it never commits, so the handler thread's connection cannot see the rows — and on SQLite the write lock the test holds blocks the handler's query outright, rather than just returning nothing. Nothing pointed at the cause, which is what sent the reporter to a workaround.

This is the same constraint the docs already explain for pytest under [*Why `transaction=True` is required*](https://github.com/dj-bolt/django-bolt/blob/master/docs/src/topics/testing.md). It just had no unittest-side counterpart, and no diagnostic.

### Changes

**Warning.** Entering a `TestClient` inside an open transaction emits `BoltTestClientWarning`, naming `TransactionTestCase` and `django_db(transaction=True)`.

Two deliberate choices, both worth your review:

- **Advisory, not fatal.** Handlers that never touch the database work correctly under `TestCase` today, and this suite contains several such tests — raising would break passing tests to fix a problem they don't have. If you'd rather it raise, say so and I'll switch it.
- **Once per process.** Without the latch it fired **72 times** in a full suite run, because the suite mixes database-free `TestClient` tests with transactional markers. With it, exactly 1. The point is to explain a confusing failure once, not to annotate every call site.

`BoltTestClientWarning` is its own category, exported from `django_bolt.testing`, so it can be silenced with `warnings.simplefilter("ignore", BoltTestClientWarning)`.

**Docs.** A *Using Django's test runner* section covering both traps, with a working `TransactionTestCase` example, and a note that `TransactionTestCase` truncates tables itself — so the manual cleanup the pytest section prescribes is not needed there.

## How was this tested?

- [x] `just lint-lib` and `just test-py` pass — 2557 passed, 7 skipped
- [ ] If Rust was changed: `just rebuild` succeeds — no Rust changes
- [ ] If a new feature is added: tested manually in the example project — bug fix + docs

Five tests in `python/tests/test_testclient_atomic_block.py`. Each behavior was verified to fail without its implementation, not just the import:

- warning call removed from `__enter__` → 2 failed
- once-per-process latch removed → 1 failed

They use pytest's `recwarn` rather than nested `catch_warnings` blocks, so no `noqa` is needed to satisfy SIM117.

Two pre-existing failures I hit and confirmed are **not** from this change — both reproduce on clean `master`:

- `test_runbolt_dev.py::test_execute_from_command_line_dev_calls_reloader_with_debounce`
- `test_type_coercion_security.py::TestDecimalEdgeCases::*` — these turned out to be a stale locally-built `_core`; they pass after `maturin build` against current master. Flagging in case CI ever shows them.

## Performance consideration

Not a hot path. The check runs once per `TestClient.__enter__`, in test code only, and short-circuits on a module-level boolean after the first warning. It reads `connections.all(initialized_only=True)`, which does not open connections, and is wrapped so an unconfigured-settings environment degrades to a debug log rather than an error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

The PR does not modify the production request path.

The transaction check runs when `TestClient` enters its synchronous or asynchronous context manager. It does not run for each request handled by Bolt.

The added work is required for the warning. It checks Django database connections once per process and caches the warning state. Database inspection failures are logged and do not interrupt tests.

The change therefore has no runtime impact on production requests. It adds a small setup-time cost when tests enter `TestClient`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->