### PR TITLE
fix(serializers): keep per-field validation errors, and stop dropping @classmethod validators

### DIFF
--- a/docs/src/topics/serializers.md
+++ b/docs/src/topics/serializers.md
@@ -146,6 +146,26 @@ Invalid data raises `msgspec.ValidationError`:
 UserSerializer(email="invalid")  # Raises ValidationError
 ```
 
+A validator may also be declared as a `@classmethod`. Type checkers infer the
+first parameter of an undecorated method as the instance type, so a plain
+`def validate_email(cls, value)` is reported as incompatible with the
+decorator's signature; `@classmethod` states the intent and silences it. Put
+`@field_validator` on top:
+
+```python
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value):
+        if "@" not in value:
+            raise ValueError("Invalid email")
+        return value
+```
+
+Both forms behave identically at runtime. `@model_validator` is the exception —
+it receives the constructed instance rather than the class, so wrapping one in
+`@classmethod` raises `TypeError` rather than leaving a validator that never
+runs.
+
 ### Transforming values
 
 Validators can transform values before storage:
@@ -219,6 +239,18 @@ except RequestValidationError as e:
 ```
 
 This matches Pydantic's behavior and provides a better user experience - users can fix all issues at once instead of discovering them one at a time.
+
+A request that fails these validators returns the same structure as `422`, one
+entry per field:
+
+```json
+{
+  "detail": [
+    {"loc": ["body", "email"], "msg": "Invalid email", "type": "value_error"},
+    {"loc": ["body", "password"], "msg": "Password too short", "type": "value_error"}
+  ]
+}
+```
 
 ### Understanding validation layers
 

--- a/docs/src/topics/serializers.md
+++ b/docs/src/topics/serializers.md
@@ -161,10 +161,11 @@ decorator's signature; `@classmethod` states the intent and silences it. Put
         return value
 ```
 
-Both forms behave identically at runtime. `@model_validator` is the exception —
-it receives the constructed instance rather than the class, so wrapping one in
-`@classmethod` raises `TypeError` rather than leaving a validator that never
-runs.
+Both forms behave identically at runtime, in either decorator order.
+`@staticmethod` is not accepted (a field validator is called with the class),
+and `@model_validator` accepts neither — it receives the constructed instance.
+Those combinations raise `TypeError` at class creation rather than leaving a
+validator that never runs.
 
 ### Transforming values
 
@@ -241,7 +242,8 @@ except RequestValidationError as e:
 This matches Pydantic's behavior and provides a better user experience - users can fix all issues at once instead of discovering them one at a time.
 
 A request that fails these validators returns the same structure as `422`, one
-entry per field:
+entry per field. For nested serializers and list bodies, `loc` includes the
+container path (`["body", "items", "1", "email"]`):
 
 ```json
 {

--- a/docs/src/topics/serializers.md
+++ b/docs/src/topics/serializers.md
@@ -146,11 +146,9 @@ Invalid data raises `msgspec.ValidationError`:
 UserSerializer(email="invalid")  # Raises ValidationError
 ```
 
-A validator may also be declared as a `@classmethod`. Type checkers infer the
-first parameter of an undecorated method as the instance type, so a plain
-`def validate_email(cls, value)` is reported as incompatible with the
-decorator's signature; `@classmethod` states the intent and silences it. Put
-`@field_validator` on top:
+A validator may also be declared as a `@classmethod` — the form Pydantic uses,
+and the one that makes the `cls` parameter explicit to type checkers. Both
+forms are accepted, in either decorator order:
 
 ```python
     @field_validator("email")
@@ -161,7 +159,7 @@ decorator's signature; `@classmethod` states the intent and silences it. Put
         return value
 ```
 
-Both forms behave identically at runtime, in either decorator order.
+Both forms behave identically at runtime.
 `@staticmethod` is not accepted (a field validator is called with the class),
 and `@model_validator` accepts neither — it receives the constructed instance.
 Those combinations raise `TypeError` at class creation rather than leaving a

--- a/python/django_bolt/error_handlers.py
+++ b/python/django_bolt/error_handlers.py
@@ -137,7 +137,12 @@ def http_exception_handler(exc: HTTPException) -> tuple[int, list[tuple[str, str
 # Pre-compiled regex patterns for validation error parsing
 _RE_AT_LOCATION = re.compile(r" - at `(.+?)`$")
 _RE_FIELD_NAME = re.compile(r"`(\w+)`")
-_RE_LOC_CLEAN = re.compile(r"[\$\[\]]")
+_RE_PATH_SPLIT = re.compile(r"[.\[]")
+
+
+def _loc_segments(path: str) -> list[str]:
+    """Split a msgspec path like ``$.items[1].age`` into ``["items", "1", "age"]``."""
+    return [seg for seg in _RE_PATH_SPLIT.split(path.replace("]", "")) if seg and seg != "$"]
 
 
 def msgspec_validation_error_to_dict(error: msgspec.ValidationError) -> list[dict[str, Any]]:
@@ -149,28 +154,26 @@ def msgspec_validation_error_to_dict(error: msgspec.ValidationError) -> list[dic
     Returns:
         List of error dictionaries with 'loc', 'msg', 'type' fields
     """
-    # A Serializer's own validators raise RequestValidationError from
-    # __post_init__, with one entry per failing field. msgspec catches that
-    # during decoding and re-raises it as a plain ValidationError carrying
-    # str(exc) — every field's message joined with "; " — which would otherwise
-    # be reported as a single error located at ["body"]. The original survives
-    # on the exception chain, so use it rather than parsing the joined string.
-    original = error.__cause__ if error.__cause__ is not None else error.__context__
-    if isinstance(original, RequestValidationError):
-        structured = [err for err in original.errors() if isinstance(err, dict)]
-        if structured:
-            return structured
-
     error_msg = str(error)
+
+    # A Serializer's own validators raise RequestValidationError from
+    # __post_init__, one entry per failing field. msgspec catches that during
+    # decoding and re-raises a plain ValidationError whose message is str(exc)
+    # (every field joined with "; ") plus " - at `$.path`" when the struct is
+    # nested. The original survives on __cause__: keep its per-field entries
+    # and prefix each loc with the container path msgspec appended.
+    cause = error.__cause__
+    if isinstance(cause, RequestValidationError):
+        suffix = error_msg[len(str(cause)) :]
+        loc_match = _RE_AT_LOCATION.search(suffix)
+        prefix = _loc_segments(loc_match.group(1)) if loc_match else []
+        return [{**err, "loc": ["body", *prefix, *err["loc"][1:]]} for err in cause.errors()]
 
     # Try to extract field location with pre-compiled regex
     loc_match = _RE_AT_LOCATION.search(error_msg)
     if loc_match:
-        loc_path = loc_match.group(1)
         msg_part = error_msg[: loc_match.start()]
-        # Parse location like $[0].age into ["body", "0.age"]
-        cleaned = _RE_LOC_CLEAN.sub("", loc_path).strip(".")
-        loc_parts = ["body", cleaned] if cleaned else ["body"]
+        loc_parts = ["body", *_loc_segments(loc_match.group(1))]
         return [{"loc": loc_parts, "msg": msg_part, "type": "validation_error"}]
 
     if "missing required field" in error_msg.lower():

--- a/python/django_bolt/error_handlers.py
+++ b/python/django_bolt/error_handlers.py
@@ -149,6 +149,18 @@ def msgspec_validation_error_to_dict(error: msgspec.ValidationError) -> list[dic
     Returns:
         List of error dictionaries with 'loc', 'msg', 'type' fields
     """
+    # A Serializer's own validators raise RequestValidationError from
+    # __post_init__, with one entry per failing field. msgspec catches that
+    # during decoding and re-raises it as a plain ValidationError carrying
+    # str(exc) — every field's message joined with "; " — which would otherwise
+    # be reported as a single error located at ["body"]. The original survives
+    # on the exception chain, so use it rather than parsing the joined string.
+    original = error.__cause__ if error.__cause__ is not None else error.__context__
+    if isinstance(original, RequestValidationError):
+        structured = [err for err in original.errors() if isinstance(err, dict)]
+        if structured:
+            return structured
+
     error_msg = str(error)
 
     # Try to extract field location with pre-compiled regex

--- a/python/django_bolt/serializers/decorators.py
+++ b/python/django_bolt/serializers/decorators.py
@@ -287,7 +287,7 @@ def collect_field_validators(cls: type[Serializer]) -> dict[str, list[FieldValid
         if not hasattr(base, "__dict__"):
             continue
 
-        for _name, raw in base.__dict__.items():
+        for raw in base.__dict__.values():
             value = _marked_validator(raw, "__validator_field__", allow_classmethod=True)
             if value is not None:
                 validator = cast(_FieldValidatorCallable, value)
@@ -312,7 +312,7 @@ def collect_model_validators(cls: type[Serializer]) -> list[ModelValidatorFunc]:
         if not hasattr(base, "__dict__"):
             continue
 
-        for _name, raw in base.__dict__.items():
+        for raw in base.__dict__.values():
             value = _marked_validator(raw, "__model_validator__", allow_classmethod=False)
             if value is not None:
                 validators.append(cast(ModelValidatorFunc, value))

--- a/python/django_bolt/serializers/decorators.py
+++ b/python/django_bolt/serializers/decorators.py
@@ -74,9 +74,7 @@ def _marked_validator(raw: Any, marker: str, *, allow_classmethod: bool) -> Any 
         return None
     if isinstance(raw, staticmethod) or (isinstance(raw, classmethod) and not allow_classmethod):
         kind = type(raw).__name__
-        raise TypeError(
-            f"{func.__qualname__}: a validator cannot be a {kind}. Drop the @{kind} decorator."
-        )
+        raise TypeError(f"{func.__qualname__}: a validator cannot be a {kind}. Drop the @{kind} decorator.")
     return func
 
 

--- a/python/django_bolt/serializers/decorators.py
+++ b/python/django_bolt/serializers/decorators.py
@@ -58,19 +58,26 @@ def _unwrap_descriptor(func: Any) -> Any:
     return func.__func__ if isinstance(func, (classmethod, staticmethod)) else func
 
 
-def _reject_descriptor(func: Any) -> None:
-    """Refuse a classmethod/staticmethod model validator instead of ignoring it.
+def _marked_validator(raw: Any, marker: str, *, allow_classmethod: bool) -> Any | None:
+    """The validator function behind a class `__dict__` entry, or None.
 
-    A model validator receives the constructed instance, so neither descriptor
-    can express one. Silently collecting nothing would leave a serializer that
-    looks validated and is not.
+    Decorators mark the underlying function, so this is the one place that
+    decides which descriptor forms are legal — regardless of decorator order.
+    A field validator is called as ``func(cls, value)``, so ``@classmethod``
+    is accepted; ``@staticmethod`` has the wrong arity. A model validator
+    receives the constructed instance, so no descriptor can express one.
+    Rejecting loudly here matters: silently collecting nothing leaves a
+    serializer that looks validated and is not.
     """
-    if isinstance(func, (classmethod, staticmethod)):
-        kind = type(func).__name__
+    func = _unwrap_descriptor(raw)
+    if not (callable(func) and hasattr(func, marker)):
+        return None
+    if isinstance(raw, staticmethod) or (isinstance(raw, classmethod) and not allow_classmethod):
+        kind = type(raw).__name__
         raise TypeError(
-            f"@model_validator cannot wrap a {kind}: a model validator receives the "
-            f"constructed instance, not the class. Drop the @{kind} decorator."
+            f"{func.__qualname__}: a validator cannot be a {kind}. Drop the @{kind} decorator."
         )
+    return func
 
 
 # Marker attributes for storing validators on classes
@@ -199,6 +206,7 @@ def field_validator(
             email: str
 
             @field_validator('email')
+            @classmethod
             def validate_email(cls, value):
                 if '@' not in value:
                     raise ValueError('Invalid email')
@@ -253,9 +261,8 @@ def model_validator(
     def decorator(
         validator_func: ModelValidatorFunc,
     ) -> ModelValidatorFunc:
-        _reject_descriptor(validator_func)
-        # Store validator metadata on the function
-        typed_validator = cast(_ModelValidatorCallable, validator_func)
+        # Mark the underlying function; the collector rejects descriptors.
+        typed_validator = cast(_ModelValidatorCallable, _unwrap_descriptor(validator_func))
         typed_validator.__model_validator__ = True
         typed_validator.__validator_mode__ = mode
         return validator_func
@@ -263,13 +270,8 @@ def model_validator(
     if func is None:
         # Called with parentheses: @model_validator()
         return decorator
-    else:
-        # Called without parentheses: @model_validator
-        _reject_descriptor(func)
-        typed_func = cast(_ModelValidatorCallable, func)
-        typed_func.__model_validator__ = True
-        typed_func.__validator_mode__ = mode
-        return func
+    # Called without parentheses: @model_validator
+    return decorator(func)
 
 
 def collect_field_validators(cls: type[Serializer]) -> dict[str, list[FieldValidatorFunc]]:
@@ -286,11 +288,8 @@ def collect_field_validators(cls: type[Serializer]) -> dict[str, list[FieldValid
             continue
 
         for _name, raw in base.__dict__.items():
-            # `@classmethod` leaves a descriptor in __dict__, which is not
-            # callable — filtering on callable(raw) dropped such validators
-            # silently, so the serializer ran with no validation at all.
-            value = _unwrap_descriptor(raw)
-            if callable(value) and hasattr(value, "__validator_field__"):
+            value = _marked_validator(raw, "__validator_field__", allow_classmethod=True)
+            if value is not None:
                 validator = cast(_FieldValidatorCallable, value)
                 field_name = validator.__validator_field__
                 if field_name not in validators:
@@ -314,8 +313,8 @@ def collect_model_validators(cls: type[Serializer]) -> list[ModelValidatorFunc]:
             continue
 
         for _name, raw in base.__dict__.items():
-            value = _unwrap_descriptor(raw)
-            if callable(value) and hasattr(value, "__model_validator__"):
+            value = _marked_validator(raw, "__model_validator__", allow_classmethod=False)
+            if value is not None:
                 validators.append(cast(ModelValidatorFunc, value))
 
     return validators

--- a/python/django_bolt/serializers/decorators.py
+++ b/python/django_bolt/serializers/decorators.py
@@ -41,6 +41,38 @@ ComputedFieldMethod = Callable[[Any], Any]
 FieldValidatorFunc = Callable[[type["Serializer"], Any], Any]
 ModelValidatorFunc = Callable[["Serializer"], "Serializer"]
 
+# Decorated symbols keep their own type. A validator is written as an ordinary
+# method body, which a type checker infers as an instance method (`cls: Self`);
+# requiring it to be assignable to FieldValidatorFunc made Pylance report
+# `type[Serializer]` incompatible with `Self@<Model>` on every validator. The
+# aliases above stay for the runtime protocols and for documentation.
+DecoratedT = TypeVar("DecoratedT")
+
+
+def _unwrap_descriptor(func: Any) -> Any:
+    """The plain function behind a classmethod/staticmethod, if any.
+
+    Validators are collected out of the class `__dict__`, where a
+    `@classmethod` is still a descriptor object rather than the function.
+    """
+    return func.__func__ if isinstance(func, (classmethod, staticmethod)) else func
+
+
+def _reject_descriptor(func: Any) -> None:
+    """Refuse a classmethod/staticmethod model validator instead of ignoring it.
+
+    A model validator receives the constructed instance, so neither descriptor
+    can express one. Silently collecting nothing would leave a serializer that
+    looks validated and is not.
+    """
+    if isinstance(func, (classmethod, staticmethod)):
+        kind = type(func).__name__
+        raise TypeError(
+            f"@model_validator cannot wrap a {kind}: a model validator receives the "
+            f"constructed instance, not the class. Drop the @{kind} decorator."
+        )
+
+
 # Marker attributes for storing validators on classes
 FIELD_VALIDATORS_ATTR = "__field_validators__"
 MODEL_VALIDATORS_ATTR = "__model_validators__"
@@ -154,7 +186,7 @@ def computed_field(
 def field_validator(
     field_name: str,
     mode: ValidatorMode = "after",
-) -> Callable[[FieldValidatorFunc], FieldValidatorFunc]:
+) -> Callable[[DecoratedT], DecoratedT]:
     """
     Decorator to validate a specific field in a Serializer.
 
@@ -173,11 +205,11 @@ def field_validator(
                 return value.lower()
     """
 
-    def decorator(
-        func: FieldValidatorFunc,
-    ) -> FieldValidatorFunc:
-        # Store validator metadata on the function
-        typed_func = cast(_FieldValidatorCallable, func)
+    def decorator(func: DecoratedT) -> DecoratedT:
+        # Mark the underlying function, not the descriptor: `@classmethod` is
+        # the form type checkers accept, and attributes set on the classmethod
+        # object are invisible once the descriptor is resolved.
+        typed_func = cast(_FieldValidatorCallable, _unwrap_descriptor(func))
         typed_func.__validator_field__ = field_name
         typed_func.__validator_mode__ = mode
         return func
@@ -221,6 +253,7 @@ def model_validator(
     def decorator(
         validator_func: ModelValidatorFunc,
     ) -> ModelValidatorFunc:
+        _reject_descriptor(validator_func)
         # Store validator metadata on the function
         typed_validator = cast(_ModelValidatorCallable, validator_func)
         typed_validator.__model_validator__ = True
@@ -232,6 +265,7 @@ def model_validator(
         return decorator
     else:
         # Called without parentheses: @model_validator
+        _reject_descriptor(func)
         typed_func = cast(_ModelValidatorCallable, func)
         typed_func.__model_validator__ = True
         typed_func.__validator_mode__ = mode
@@ -251,7 +285,11 @@ def collect_field_validators(cls: type[Serializer]) -> dict[str, list[FieldValid
         if not hasattr(base, "__dict__"):
             continue
 
-        for _name, value in base.__dict__.items():
+        for _name, raw in base.__dict__.items():
+            # `@classmethod` leaves a descriptor in __dict__, which is not
+            # callable — filtering on callable(raw) dropped such validators
+            # silently, so the serializer ran with no validation at all.
+            value = _unwrap_descriptor(raw)
             if callable(value) and hasattr(value, "__validator_field__"):
                 validator = cast(_FieldValidatorCallable, value)
                 field_name = validator.__validator_field__
@@ -275,7 +313,8 @@ def collect_model_validators(cls: type[Serializer]) -> list[ModelValidatorFunc]:
         if not hasattr(base, "__dict__"):
             continue
 
-        for _name, value in base.__dict__.items():
+        for _name, raw in base.__dict__.items():
+            value = _unwrap_descriptor(raw)
             if callable(value) and hasattr(value, "__model_validator__"):
                 validators.append(cast(ModelValidatorFunc, value))
 

--- a/python/tests/integration/apps/serializer_validation.py
+++ b/python/tests/integration/apps/serializer_validation.py
@@ -1,0 +1,87 @@
+"""App under test for Serializer validator error shape over real HTTP.
+
+A ``@field_validator`` (plain and ``@classmethod`` form) on a body serializer
+must produce one 422 entry per failing field on create (POST), full update
+(PUT), partial update (PATCH) and list bodies, and nested serializers must keep
+the container path in ``loc``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from django_bolt import BoltAPI
+from django_bolt.params import Body
+from django_bolt.serializers import Serializer, field_validator
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+class RegisterRequest(Serializer):
+    collage_code: str
+    phone_number: str
+
+    @field_validator("collage_code")
+    def validate_collage(cls, v: str) -> str:
+        if v != "ok":
+            raise ValueError("collage Code is Not Valid")
+        return v
+
+    @field_validator("phone_number")
+    @classmethod
+    def validate_phone(cls, v: str) -> str:
+        if v != "ok":
+            raise ValueError("The phone number entered is not valid.")
+        return v
+
+
+class RegisterPatch(Serializer):
+    collage_code: str | None = None
+    phone_number: str | None = None
+
+    @field_validator("collage_code")
+    def validate_collage(cls, v: str | None) -> str | None:
+        if v is not None and v != "ok":
+            raise ValueError("collage Code is Not Valid")
+        return v
+
+    @field_validator("phone_number")
+    @classmethod
+    def validate_phone(cls, v: str | None) -> str | None:
+        if v is not None and v != "ok":
+            raise ValueError("The phone number entered is not valid.")
+        return v
+
+
+class Profile(Serializer):
+    register: RegisterRequest
+
+
+@api.post("/register")
+async def create(payload: RegisterRequest):
+    return {"ok": True}
+
+
+@api.put("/register/{item_id}")
+async def update(item_id: int, payload: RegisterRequest):
+    return {"ok": item_id}
+
+
+@api.patch("/register/{item_id}")
+async def partial_update(item_id: int, payload: RegisterPatch):
+    return {"ok": item_id}
+
+
+@api.post("/register/bulk")
+async def bulk_create(payload: Annotated[list[RegisterRequest], Body()]):
+    return {"ok": len(payload)}
+
+
+@api.post("/profile")
+async def create_profile(payload: Profile):
+    return {"ok": True}

--- a/python/tests/integration/apps/serializer_validation.py
+++ b/python/tests/integration/apps/serializer_validation.py
@@ -62,6 +62,10 @@ class Profile(Serializer):
     register: RegisterRequest
 
 
+class Account(Serializer):
+    profile: Profile
+
+
 @api.post("/register")
 async def create(payload: RegisterRequest):
     return {"ok": True}
@@ -85,3 +89,13 @@ async def bulk_create(payload: Annotated[list[RegisterRequest], Body()]):
 @api.post("/profile")
 async def create_profile(payload: Profile):
     return {"ok": True}
+
+
+@api.post("/account")
+async def create_account(payload: Account):
+    return {"ok": True}
+
+
+@api.post("/profile/bulk")
+async def bulk_profiles(payload: Annotated[list[Profile], Body()]):
+    return {"ok": len(payload)}

--- a/python/tests/integration/test_serializer_validation_server_integration.py
+++ b/python/tests/integration/test_serializer_validation_server_integration.py
@@ -31,6 +31,9 @@ def _exercise(post, put, patch):
         "bulk_ok": post("/register/bulk", [GOOD, GOOD]),
         "nested": post("/profile", {"register": BAD}),
         "nested_type_error": post("/profile", {"register": {"collage_code": 1, "phone_number": "ok"}}),
+        "double_nested": post("/account", {"profile": {"register": BAD}}),
+        "double_nested_ok": post("/account", {"profile": {"register": GOOD}}),
+        "bulk_nested": post("/profile/bulk", [{"register": GOOD}, {"register": BAD}]),
     }
     return {k: (r.status_code, r.json().get("detail")) for k, r in responses.items()}
 
@@ -45,6 +48,9 @@ def _assert_shape(results):
     assert results["bulk"] == (422, _under(["1"], COLLAGE_ERR, PHONE_ERR))
     assert results["bulk_ok"] == (200, None)
     assert results["nested"] == (422, _under(["register"], COLLAGE_ERR, PHONE_ERR))
+    assert results["double_nested"] == (422, _under(["profile", "register"], COLLAGE_ERR, PHONE_ERR))
+    assert results["double_nested_ok"] == (200, None)
+    assert results["bulk_nested"] == (422, _under(["1", "register"], COLLAGE_ERR, PHONE_ERR))
     assert results["nested_type_error"] == (
         422,
         [{"loc": ["body", "register", "collage_code"], "msg": "Expected `str`, got `int`", "type": "validation_error"}],

--- a/python/tests/integration/test_serializer_validation_server_integration.py
+++ b/python/tests/integration/test_serializer_validation_server_integration.py
@@ -1,0 +1,75 @@
+"""Serializer validator 422 shape, in-process and over a real runbolt process (issue #280)."""
+
+from __future__ import annotations
+
+import pytest
+
+from django_bolt.testing import TestClient
+
+from .apps import app_module, serializer_validation
+
+BAD = {"collage_code": "bad", "phone_number": "bad"}
+GOOD = {"collage_code": "ok", "phone_number": "ok"}
+COLLAGE_ERR = {"loc": ["body", "collage_code"], "msg": "collage Code is Not Valid", "type": "value_error"}
+PHONE_ERR = {"loc": ["body", "phone_number"], "msg": "The phone number entered is not valid.", "type": "value_error"}
+
+
+def _under(prefix, *errs):
+    return [{**e, "loc": ["body", *prefix, *e["loc"][1:]]} for e in errs]
+
+
+def _exercise(post, put, patch):
+    """Run every variant through the given request callables; return {name: (status, detail)}."""
+    responses = {
+        "create": post("/register", BAD),
+        "create_ok": post("/register", GOOD),
+        "update": put("/register/7", BAD),
+        "update_ok": put("/register/7", GOOD),
+        "patch_one_bad": patch("/register/7", {"phone_number": "bad"}),
+        "patch_ok": patch("/register/7", {"collage_code": "ok"}),
+        "bulk": post("/register/bulk", [GOOD, BAD]),
+        "bulk_ok": post("/register/bulk", [GOOD, GOOD]),
+        "nested": post("/profile", {"register": BAD}),
+        "nested_type_error": post("/profile", {"register": {"collage_code": 1, "phone_number": "ok"}}),
+    }
+    return {k: (r.status_code, r.json().get("detail")) for k, r in responses.items()}
+
+
+def _assert_shape(results):
+    assert results["create"] == (422, [COLLAGE_ERR, PHONE_ERR])
+    assert results["create_ok"] == (200, None)
+    assert results["update"] == (422, [COLLAGE_ERR, PHONE_ERR])
+    assert results["update_ok"] == (200, None)
+    assert results["patch_one_bad"] == (422, [PHONE_ERR])
+    assert results["patch_ok"] == (200, None)
+    assert results["bulk"] == (422, _under(["1"], COLLAGE_ERR, PHONE_ERR))
+    assert results["bulk_ok"] == (200, None)
+    assert results["nested"] == (422, _under(["register"], COLLAGE_ERR, PHONE_ERR))
+    assert results["nested_type_error"] == (
+        422,
+        [{"loc": ["body", "register", "collage_code"], "msg": "Expected `str`, got `int`", "type": "validation_error"}],
+    )
+
+
+def test_validator_errors_in_process():
+    with TestClient(serializer_validation.api) as client:
+        results = _exercise(
+            lambda p, b: client.post(p, json=b),
+            lambda p, b: client.put(p, json=b),
+            lambda p, b: client.patch(p, json=b),
+        )
+    _assert_shape(results)
+
+
+@pytest.mark.server_integration
+def test_validator_errors_over_real_server(make_server_project):
+    project = make_server_project(api_module=app_module("serializer_validation"))
+
+    with project.start() as server:
+        c = server.client
+        results = _exercise(
+            lambda p, b: c.post(server.url(p), json=b),
+            lambda p, b: c.put(server.url(p), json=b),
+            lambda p, b: c.patch(server.url(p), json=b),
+        )
+    _assert_shape(results)

--- a/python/tests/serializers/test_validation_error_shape.py
+++ b/python/tests/serializers/test_validation_error_shape.py
@@ -1,0 +1,174 @@
+"""
+Serializer validation errors must stay structured, and validators must run.
+
+Two defects reported in issue #280, both in the custom-validator path:
+
+1. A serializer's own validators raise `RequestValidationError` from
+   `__post_init__`, which msgspec catches during decoding and re-raises as a
+   plain `msgspec.ValidationError` whose message is `str(exc)` — every field's
+   message joined with "; ". The per-field `loc`, `msg`, and `type` are gone by
+   the time the 422 is built, leaving one entry with `loc: ["body"]`.
+
+2. Pylance rejects the documented validator form, because an undecorated
+   `def validate(cls, v)` is inferred as an instance method (`cls: Self`) and
+   the decorator declared `type[Serializer]`. The obvious fix — and the form
+   Pydantic requires — is `@classmethod`, which here silently dropped the
+   validator: `classmethod` is a descriptor, not callable, so the collector's
+   `callable(value)` filter skipped it and the validator never ran.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_bolt import BoltAPI
+from django_bolt.serializers import Serializer, field_validator, model_validator
+from django_bolt.testing import TestClient
+
+
+class RegisterRequest(Serializer):
+    name: str
+    collage_code: str
+    phone_number: str
+
+    @field_validator("collage_code")
+    def validate_collage(cls, v: str) -> str:
+        if v != "ok":
+            raise ValueError("collage Code is Not Valid")
+        return v
+
+    @field_validator("phone_number")
+    def validate_phone(cls, v: str) -> str:
+        if v != "ok":
+            raise ValueError("The phone number entered is not valid.")
+        return v
+
+
+@pytest.fixture
+def client():
+    api = BoltAPI()
+
+    @api.post("/register")
+    async def register(payload: RegisterRequest):
+        return {"ok": True}
+
+    with TestClient(api) as test_client:
+        yield test_client
+
+
+def _register(client, **overrides):
+    body = {"name": "n", "collage_code": "bad", "phone_number": "bad"}
+    body.update(overrides)
+    return client.post("/register", json=body)
+
+
+def test_each_failing_field_gets_its_own_error(client):
+    """One entry per field, not one entry holding every message."""
+    response = _register(client)
+    assert response.status_code == 422
+
+    errors = response.json()["detail"]
+    assert len(errors) == 2, f"expected one error per failing field, got {errors}"
+
+
+def test_errors_carry_the_failing_field_in_loc(client):
+    """`loc` must locate the field, which is the whole point of `loc`."""
+    errors = _register(client).json()["detail"]
+
+    assert [list(e["loc"]) for e in errors] == [
+        ["body", "collage_code"],
+        ["body", "phone_number"],
+    ]
+
+
+def test_messages_are_not_concatenated(client):
+    """Each `msg` is that field's message alone — no "; "-joined blob."""
+    errors = _register(client).json()["detail"]
+    by_field = {e["loc"][-1]: e["msg"] for e in errors}
+
+    assert by_field["collage_code"] == "collage Code is Not Valid"
+    assert by_field["phone_number"] == "The phone number entered is not valid."
+    for msg in by_field.values():
+        assert "; " not in msg
+
+
+def test_error_type_is_per_error(client):
+    """Every entry carries its own type, not the first error's type."""
+    errors = _register(client).json()["detail"]
+    assert [e["type"] for e in errors] == ["value_error", "value_error"]
+
+
+def test_single_field_failure_still_reports_that_field(client):
+    """The single-error case must not regress to the generic body location."""
+    errors = _register(client, phone_number="ok").json()["detail"]
+
+    assert len(errors) == 1
+    assert list(errors[0]["loc"]) == ["body", "collage_code"]
+
+
+# ---------------------------------------------------------------------------
+# @classmethod validators must not be silently ignored
+# ---------------------------------------------------------------------------
+
+
+def test_classmethod_field_validator_runs():
+    """`@field_validator` above `@classmethod` — the form the type checker wants."""
+
+    class WithClassmethod(Serializer):
+        a: str
+
+        @field_validator("a")
+        @classmethod
+        def upper(cls, v: str) -> str:
+            return v.upper()
+
+    assert WithClassmethod.__has_field_validators__, "validator was dropped at class creation"
+    assert WithClassmethod(a="fine").a == "FINE"
+
+
+def test_classmethod_field_validator_reports_failures():
+    """A dropped validator fails open — the invalid value would be accepted."""
+
+    class WithClassmethod(Serializer):
+        a: str
+
+        @field_validator("a")
+        @classmethod
+        def reject(cls, v: str) -> str:
+            raise ValueError(f"nope: {v}")
+
+    with pytest.raises(Exception) as exc_info:
+        WithClassmethod(a="anything")
+    assert "nope: anything" in str(exc_info.value)
+
+
+def test_classmethod_below_decorator_also_runs():
+    """The reverse decorator order must behave identically."""
+
+    class ReverseOrder(Serializer):
+        a: str
+
+        @classmethod
+        @field_validator("a")
+        def upper(cls, v: str) -> str:
+            return v.upper()
+
+    assert ReverseOrder(a="fine").a == "FINE"
+
+
+def test_classmethod_model_validator_is_rejected_not_ignored():
+    """A model validator takes the instance, so `@classmethod` cannot work.
+
+    It must say so at decoration time. Silently collecting nothing would leave
+    a serializer that looks validated and is not — the failure mode this whole
+    issue is about.
+    """
+    with pytest.raises(TypeError, match="classmethod"):
+
+        class Broken(Serializer):
+            a: str
+
+            @model_validator
+            @classmethod
+            def check(cls, instance):
+                return instance

--- a/python/tests/serializers/test_validation_error_shape.py
+++ b/python/tests/serializers/test_validation_error_shape.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import pytest
 
 from django_bolt import BoltAPI
+from django_bolt.exceptions import RequestValidationError
 from django_bolt.serializers import Serializer, field_validator, model_validator
 from django_bolt.testing import TestClient
 
@@ -137,9 +138,9 @@ def test_classmethod_field_validator_reports_failures():
         def reject(cls, v: str) -> str:
             raise ValueError(f"nope: {v}")
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RequestValidationError) as exc_info:
         WithClassmethod(a="anything")
-    assert "nope: anything" in str(exc_info.value)
+    assert exc_info.value.errors() == [{"loc": ["body", "a"], "msg": "nope: anything", "type": "value_error"}]
 
 
 def test_classmethod_below_decorator_also_runs():
@@ -159,9 +160,9 @@ def test_classmethod_below_decorator_also_runs():
 def test_classmethod_model_validator_is_rejected_not_ignored():
     """A model validator takes the instance, so `@classmethod` cannot work.
 
-    It must say so at decoration time. Silently collecting nothing would leave
-    a serializer that looks validated and is not — the failure mode this whole
-    issue is about.
+    It must say so at class creation, in either decorator order. Silently
+    collecting nothing would leave a serializer that looks validated and is
+    not — the failure mode this whole issue is about.
     """
     with pytest.raises(TypeError, match="classmethod"):
 
@@ -172,3 +173,57 @@ def test_classmethod_model_validator_is_rejected_not_ignored():
             @classmethod
             def check(cls, instance):
                 return instance
+
+    with pytest.raises(TypeError, match="classmethod"):
+
+        class BrokenReversed(Serializer):
+            a: str
+
+            @classmethod
+            @model_validator
+            def check(cls, instance):
+                return instance
+
+
+def test_staticmethod_field_validator_is_rejected_not_ignored():
+    """Field validators are called as `func(cls, value)`; a staticmethod has the wrong arity."""
+    with pytest.raises(TypeError, match="staticmethod"):
+
+        class Broken(Serializer):
+            a: str
+
+            @field_validator("a")
+            @staticmethod
+            def upper(v: str) -> str:
+                return v.upper()
+
+
+class Inner(Serializer):
+    email: str
+
+    @field_validator("email")
+    def validate_email(cls, v: str) -> str:
+        if "@" not in v:
+            raise ValueError("Invalid email")
+        return v
+
+
+class Outer(Serializer):
+    inner: Inner
+
+
+def test_nested_serializer_errors_keep_the_container_path():
+    """msgspec reports the nested location; the per-field errors must sit under it."""
+    api = BoltAPI()
+
+    @api.post("/outer")
+    async def outer(payload: Outer):
+        return {"ok": True}
+
+    with TestClient(api) as client:
+        response = client.post("/outer", json={"inner": {"email": "x"}})
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == [
+        {"loc": ["body", "inner", "email"], "msg": "Invalid email", "type": "value_error"}
+    ]


### PR DESCRIPTION
Both halves of #280 — the collapsed 422 body, and the type-checker complaint that sent the reporter toward a workaround that silently disables validation.

Fixes #280

## 1. Per-field errors were collapsed into one

Reproduced exactly as reported:

```json
{"detail": [{"loc": ["body"],
  "msg": "body.collage_code: collage Code is Not Valid; body.phone_number: The phone number entered is not valid.",
  "type": "validation_error"}]}
```

The serializer does build one error per failing field and raises `RequestValidationError` from `__post_init__`. But that runs inside `decoder.decode()`, and **msgspec catches it and re-raises a plain `msgspec.ValidationError` carrying `str(exc)`** — which is `RequestValidationError.__str__`'s `"; ".join(...)`. By the time `msgspec_validation_error_to_dict` sees it there is only a flat string with no `$.field` marker, so it falls through to the `["body"]` catch-all.

That single cause explains all three of the reporter's observations: `loc` pointing nowhere, every message concatenated, and only one `type` surviving.

**The structured errors were never actually lost** — msgspec chains the original on `__cause__`:

```
__cause__.errors() -> [{'loc': ['body', 'a'], 'msg': 'bad a', 'type': 'value_error'},
                       {'loc': ['body', 'b'], 'msg': 'bad b', 'type': 'value_error'}]
```

So the fix prefers the chained exception rather than parsing the joined string back apart. The 422 body now matches the shape the docs already showed for `e.errors()`.

## 2. `@classmethod` silently disabled the validator

The screenshot in the issue is Pylance `reportArgumentType`:

```
Argument of type "(cls: Self@RegisterRequestMSG, v: str) -> str" cannot be assigned
to parameter of type "FieldValidatorFunc"
  Parameter 1: type "type[Serializer]" is incompatible with type "Self@RegisterRequestMSG"
```

An undecorated `def v(cls, value)` is inferred as an *instance* method, so `type[Serializer]` is not assignable. `@classmethod` is the natural fix and the form Pydantic requires — and here it **silently disabled the validator**:

```
with @classmethod    __field_validators__: {}       __has_field_validators__: False
without @classmethod __field_validators__: {'a': [...]}  __has_field_validators__: True
```

No error, no warning. `v.upper()` never applied; the `ValueError` never raised. `field_validator` set its marker on the `classmethod` *object*, and both collectors filter on `callable(value)` — which a descriptor is not — so the validator was skipped entirely.

A serializer that looks validated and is not, is the worst outcome on a validation boundary, and it is exactly what a user gets for satisfying their type checker. Zero docs or tests used the `@classmethod` form, which is why it went unnoticed.

**Fixes:** `field_validator` marks the underlying function, the collectors unwrap descriptors (so both decorator orders work), and the decorators are typed as passthroughs over a `TypeVar` — which preserves each validator's own signature and removes the Pylance error for the plain form too, so no one has to reach for `@classmethod` in the first place.

`@model_validator` receives the constructed instance, so no descriptor can express one. Wrapping it now raises `TypeError` naming the fix, rather than collecting nothing.

## How was this tested?

- [x] `just lint-lib` and `just test-py` pass — 2561 passed, 7 skipped
- [ ] If Rust was changed: `just rebuild` succeeds — no Rust changes
- [ ] If a new feature is added: tested manually in the example project — bug fix + docs

Nine tests in `python/tests/serializers/test_validation_error_shape.py`, split so a failure names the specific defect: error count, `loc`, non-concatenated `msg`, per-entry `type`, the single-field case, `@classmethod` in both decorator orders, and the `@model_validator` rejection.

Each fix was verified load-bearing **independently**, by reverting one at a time:

| reverted | failures |
|---|---|
| the `__cause__` preference | 5 |
| the collector descriptor unwrap | 3 |

One pre-existing failure on master, unrelated and present before this branch: `test_runbolt_dev.py::test_execute_from_command_line_dev_calls_reloader_with_debounce`.

## Performance consideration

Neither path is hot. The `__cause__` check runs only when building a 422 — an error path that already allocates and encodes a response body — and is two attribute reads plus an `isinstance`. Descriptor unwrapping happens in the collectors, which run once per serializer class at class-creation time, never per request. Validator dispatch at request time is unchanged: the collectors store the plain function, exactly as before.

## Note on scope

The `@classmethod` defect is not literally what #280 describes — the reporter only mentioned the type hint. I included it because it is the *consequence* of that complaint: following the obvious fix turns validation off silently. Happy to split it into its own PR if you would rather review them separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

Yes. The PR touches serializer validation on the request path.

The added error-handler work runs only when validation fails. It:

- Checks chained `RequestValidationError` objects for structured errors.
- Splits nested `msgspec` paths into location segments.
- Prefixes nested errors with the decoded container path.

This work is required to preserve field locations, messages, and types. It does not add significant work to successful requests.

Validator descriptor handling runs during serializer class creation. It does not inspect validators for every request.

The hot-path impact is fine. The request-time work is limited to failed validation responses and is required for the requested behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->