### PR TITLE
Serializer loading plans, OpenAPI codegen gaps, public MCP OAuth routes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,13 +49,22 @@ jobs:
 
   # Run tests across Python versions
   test:
-    name: Test Python ${{ matrix.python-version }}
+    name: Test Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }}
     runs-on: ubuntu-latest
     needs: python-versions
     strategy:
       fail-fast: false
       matrix:
         python-version: ${{ fromJSON(needs.python-versions.outputs.versions-json) }}
+        # Newest supported Django on every Python; older Django series on the
+        # newest Python each of them supports (see pyproject classifiers).
+        django-version: ["6.1"]
+        include:
+          - { python-version: "3.12", django-version: "4.2" }
+          - { python-version: "3.12", django-version: "5.0" }
+          - { python-version: "3.13", django-version: "5.1" }
+          - { python-version: "3.13", django-version: "5.2" }
+          - { python-version: "3.14", django-version: "6.0" }
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -82,19 +91,24 @@ jobs:
           rustflags: "" # action defaults to -D warnings; don't block tests on warnings
 
       - name: Install dependencies
+        # One explicit sync (dev group pins the newest Django), then swap in the
+        # matrix Django. Every later `uv run` is --no-sync so the lockfile's
+        # Django is not reinstalled over it.
         run: |
-          uv pip install -e ".[dev]" -e python/bolt-mcp
+          uv sync --all-extras
+          uv pip install "django~=${{ matrix.django-version }}.0"
+          uv run --no-sync python -c "import django; print('Django', django.__version__)"
 
       - name: Build extension
-        run: uv run maturin develop --release
+        run: uv run --no-sync maturin develop --release
 
       - name: Run tests
-        run: uv run --with pytest pytest python/tests -m "not server_integration and not artifact_smoke" -s -vv
+        run: uv run --no-sync --with pytest pytest python/tests -m "not server_integration and not artifact_smoke" -s -vv
 
       # Separate invocation: bolt-mcp's conftest configures Django (OAuth app,
       # file-backed sqlite) incompatibly with the main suite's settings.
       - name: Run bolt-mcp tests
-        run: uv run --with pytest pytest python/bolt-mcp/tests -m "not server_integration and not artifact_smoke" -s -vv
+        run: uv run --no-sync --with pytest pytest python/bolt-mcp/tests -m "not server_integration and not artifact_smoke" -s -vv
 
   server_smoke_linux:
     name: Server Smoke Linux

--- a/docs/src/topics/openapi.md
+++ b/docs/src/topics/openapi.md
@@ -51,8 +51,25 @@ OpenAPIConfig(
     docs_url="/docs",            # Swagger UI URL
     openapi_url="/openapi.json", # OpenAPI JSON URL
     django_auth=False,           # Enable Django admin auth for docs
+    strict=False,                # Fail generation on untypeable shapes (see below)
 )
 ```
+
+### Strict mode
+
+Set `OpenAPIConfig(strict=True)` to make schema generation fail on shapes that
+client code generators cannot type. `SchemaGenerator.generate()` raises
+`OpenAPIStrictError`. The error lists all problems at the same time. These are
+the problems:
+
+- A route has the success response `{"type": "object"}`. The route has no
+  return annotation and no `response_model`.
+- A component name uses the long form `module.qualname`. This occurs when two
+  types have the same short name.
+
+Routes with `include_in_schema=False` are not problems. Routes with a non-JSON
+`response_class` are not problems. Run strict mode in CI to keep the generated
+clients correct.
 
 ## Documenting endpoints
 
@@ -362,13 +379,36 @@ async def search(
 
 ## Hiding endpoints
 
-Exclude endpoints from documentation:
+Remove endpoints from the documentation. The server continues to serve them:
 
 ```python
 @api.get("/internal", include_in_schema=False)
 async def internal():
     return {"internal": True}
 ```
+
+## Non-JSON responses
+
+`response_class` sets the media type in the documentation. The default is
+`application/json`:
+
+| `response_class` | Media type | Schema |
+|---|---|---|
+| `HTML` | `text/html` | string |
+| `PlainText` | `text/plain` | string |
+| `File`, `FileResponse`, `StreamingResponse` | `application/octet-stream` | string / binary |
+| `EventSourceResponse` | `text/event-stream` | string |
+| `Redirect` | none (status 307, or the `status_code` of the route) | `Location` header only |
+
+```python
+@api.get("/report.csv", response_class=File)
+async def report():
+    return File("/srv/report.csv")
+```
+
+Each parametrization of a generic response model gets its own component name.
+This is the same as msgspec. `Page[UserRead]` becomes the component
+`Page_UserRead_`. Its title is `Page[UserRead]`.
 
 ## OpenAPI extensions
 

--- a/docs/src/topics/pagination.md
+++ b/docs/src/topics/pagination.md
@@ -131,30 +131,67 @@ class ArticleViewSet(ModelViewSet):
     pagination_class = ArticlePagination  # Automatically applied to list()
 ```
 
+## Custom response envelope
+
+The default envelope is `PaginatedResponse[T]`. It has `items`, `total`,
+`has_next`, `has_previous` and the fields of the pagination scheme. You can use
+a different shape, for example the DRF shape `count/next/previous/results`. Set
+`response_class` to a generic `Serializer` or `msgspec.Struct`. Then override
+`build_response()`. The response body and the OpenAPI schema
+(`DRFPage_ArticleSerializer_`) use the new shape:
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class DRFPage(Serializer, Generic[T]):
+    count: int
+    next: str | None
+    previous: str | None
+    results: list[T]
+
+class DRFPagination(PageNumberPagination):
+    page_size = 20
+    response_class = DRFPage
+
+    def build_response(self, items, *, total, request, page, page_size, has_next, has_previous, **info):
+        base = f"{request.path}?page_size={page_size}&page="
+        return DRFPage(
+            count=total,
+            next=f"{base}{page + 1}" if has_next else None,
+            previous=f"{base}{page - 1}" if has_previous else None,
+            results=items,
+        )
+```
+
+`build_response()` gets the serialized `items`, the `total`, the `request` and
+the `has_next` and `has_previous` flags. It also gets the fields of the scheme
+as keyword arguments:
+
+- Page number: `page`, `page_size`, `total_pages`, `next_page`, `previous_page`
+- Limit/offset: `limit`, `offset`
+- Cursor: `page_size`, `next_cursor`
+
 ## Performance Considerations
 
 ### Avoiding N+1 Queries
 
-Serialization happens after fetching items. If your serializer accesses related fields, use `select_related()` or `prefetch_related()` to avoid N+1 queries:
+If the item type is a Bolt `Serializer`, Bolt applies the loading plan of the
+serializer to the page QuerySet. The plan uses `select_related` for ForeignKey
+and OneToOne fields, `prefetch_related` for many-valued relations, and
+`Config.annotations`. Nested relations cost a small, fixed number of queries
+for each page. See
+[Loading a QuerySet with from_models()](serializers.md#loading-a-queryset-with-from_models).
+
+Bolt keeps the loads that you apply. Bolt does not apply them a second time.
+This code is correct:
 
 ```python
-# Bad - N+1 queries when serializer accesses article.author
 @api.get("/articles")
 @paginate(ArticlePagination)
 async def list_articles(request) -> list[ArticleSerializer]:
-    return Article.objects.all()
-
-# Good - single query with JOIN
-@api.get("/articles")
-@paginate(ArticlePagination)
-async def list_articles(request) -> list[ArticleSerializer]:
-    return Article.objects.select_related("author").all()
-
-# Good - prefetch for many-to-many
-@api.get("/articles")
-@paginate(ArticlePagination)
-async def list_articles(request) -> list[ArticleSerializer]:
-    return Article.objects.prefetch_related("tags").all()
+    return Article.objects.select_related("author").prefetch_related("tags")
 ```
 
 ### Cursor vs PageNumber for Large Datasets

--- a/docs/src/topics/serializers.md
+++ b/docs/src/topics/serializers.md
@@ -704,6 +704,41 @@ user = await User.objects.prefetch_related("addresses").aget(id=1)
 serializer = UserSerializer.from_model(user)
 ```
 
+### Loading a QuerySet with from_models()
+
+A serializer knows which relations it reads. Thus it can prepare the QuerySet.
+`from_models()` makes a loading plan from the serializer fields. It applies the
+plan to the QuerySet before it reads the rows:
+
+- ForeignKey and OneToOne fields use `select_related`. Dotted sources such as `field(source="author.email")` also use `select_related`.
+- ManyToMany and reverse relations use `prefetch_related`. A nested serializer adds its own plan to the `Prefetch`.
+- `Config.annotations` uses `annotate`.
+- Django 6.1 and later: `fetch_mode(FETCH_PEERS)` applies to all other fields.
+
+```python
+class PostSerializer(Serializer):
+    class Config:
+        annotations = {"comment_count": Count("comments")}
+
+    id: int
+    title: str
+    author: AuthorSerializer          # select_related("author")
+    tags: list[TagSerializer]         # prefetch_related("tags")
+    comment_count: int                # annotate(...)
+
+posts = PostSerializer.from_models(BlogPost.objects.filter(published=True))   # sync
+posts = await PostSerializer.afrom_models(BlogPost.objects.all())            # async (async ORM iteration)
+```
+
+The plan only adds loads. Bolt keeps the `select_related`, `prefetch_related`
+and `annotate` calls that you applied. Bolt does not apply them a second time.
+If you give a list of model instances, Bolt uses the list as it is.
+Use `loading_plan(Model)` to see the plan.
+
+A route with the annotation `list[PostSerializer]` can return a QuerySet. This
+also applies to `@paginate` routes. Bolt applies the plan to that QuerySet. You
+do not write more code. There is no N+1.
+
 ### Bulk serialization
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
@@ -83,7 +84,7 @@ dev = [
     "pydantic>=2",
     "pyyaml>=5.2",
     "maturin>=1.9.6",
-    "django==6.0.7",
+    "django==6.1",
     "ruff>=0.8",
     "vulture>=2.11", #for dead code detection
     "nanodjango>=0.16",

--- a/python/bolt-mcp/src/bolt_mcp/mount.py
+++ b/python/bolt-mcp/src/bolt_mcp/mount.py
@@ -192,7 +192,7 @@ def mount_mcp(
         # RFC 9728 location derived from the resource identifier: path-aware
         # for a resource with a path, root for a path-less resource. The
         # WWW-Authenticate challenge points at the same URL.
-        api.get(f"{WELL_KNOWN_PROTECTED_RESOURCE}{resource_path}")(_mcp_protected_resource_metadata)
+        api.get(f"{WELL_KNOWN_PROTECTED_RESOURCE}{resource_path}", auth=[], guards=[])(_mcp_protected_resource_metadata)
 
     secret_key = getattr(settings, "SECRET_KEY", "")
     if not secret_key:

--- a/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
@@ -1,6 +1,6 @@
 """OAuth Authorization Server HTTP endpoints, registered on a ``BoltAPI``.
 
-Routes (all public — ``auth=None``):
+Routes (all public — ``auth=[], guards=[]`` so global defaults never gate them):
   GET  /.well-known/oauth-authorization-server   RFC 8414 metadata
   POST {prefix}/register                         RFC 7591 Dynamic Client Registration
   GET  {prefix}/authorize                         login / consent (Authorization Code)
@@ -307,10 +307,10 @@ def register_oauth_endpoints(api: BoltAPI, server: AuthorizationServer) -> None:
         return JSON({}, headers=_NO_STORE)
 
     # ── registration ─────────────────────────────────────────────────────────────
-    api.get(WELL_KNOWN_AUTHORIZATION_SERVER, auth=None)(_as_metadata)
-    api.get(server.path("authorize"), auth=None)(_authorize_get)
-    api.post(server.path("authorize"), auth=None)(_authorize_post)
-    api.post(server.path("token"), auth=None)(_token)
-    api.post(server.path("revoke"), auth=None)(_revoke)
+    api.get(WELL_KNOWN_AUTHORIZATION_SERVER, auth=[], guards=[])(_as_metadata)
+    api.get(server.path("authorize"), auth=[], guards=[])(_authorize_get)
+    api.post(server.path("authorize"), auth=[], guards=[])(_authorize_post)
+    api.post(server.path("token"), auth=[], guards=[])(_token)
+    api.post(server.path("revoke"), auth=[], guards=[])(_revoke)
     if server.allow_dynamic_registration:
-        api.post(server.path("register"), auth=None)(_register)
+        api.post(server.path("register"), auth=[], guards=[])(_register)

--- a/python/bolt-mcp/tests/test_oauth_as.py
+++ b/python/bolt-mcp/tests/test_oauth_as.py
@@ -12,6 +12,7 @@ import secrets
 from urllib.parse import parse_qs, urlsplit
 
 import jwt
+import pytest
 from _helpers import initialize, parse_rpc, post_rpc
 from bolt_mcp import MCP, AuthorizationServer, mount_mcp
 from bolt_mcp.oauth import sessions as oauth_sessions
@@ -22,6 +23,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from django_bolt import BoltAPI, Requires
+from django_bolt.auth import IsAuthenticated, JWTAuthentication
 from django_bolt.testing import TestClient
 
 ISSUER = "http://localhost:8000"
@@ -542,3 +544,20 @@ def test_registration_rejects_invalid_application_type():
         )
     assert r.status_code == 400
     assert r.json()["error"] == "invalid_client_metadata"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_oauth_routes_are_public_under_global_default_guards(settings):
+    """#296: BOLT_DEFAULT_PERMISSION_CLASSES / BOLT_AUTHENTICATION_CLASSES must not
+    gate discovery or the OAuth endpoints — a client has no token before the flow."""
+    settings.BOLT_AUTHENTICATION_CLASSES = [JWTAuthentication()]
+    settings.BOLT_DEFAULT_PERMISSION_CLASSES = [IsAuthenticated()]
+    api, _mcp, _server = _build()
+
+    with TestClient(api) as client:
+        assert client.get("/.well-known/oauth-authorization-server").status_code == 200
+        assert client.get("/.well-known/oauth-protected-resource/mcp").status_code == 200
+        assert client.get("/oauth/authorize").status_code != 401
+        assert client.post("/oauth/token", data={"grant_type": "authorization_code"}).status_code != 401
+        assert client.post("/oauth/revoke", data={"token": "x"}).status_code != 401
+        assert client.post("/oauth/register", json={"redirect_uris": [REDIRECT_URI]}).status_code != 401

--- a/python/bolt-mcp/tests/test_oauth_as.py
+++ b/python/bolt-mcp/tests/test_oauth_as.py
@@ -557,7 +557,14 @@ def test_oauth_routes_are_public_under_global_default_guards(settings):
     with TestClient(api) as client:
         assert client.get("/.well-known/oauth-authorization-server").status_code == 200
         assert client.get("/.well-known/oauth-protected-resource/mcp").status_code == 200
-        assert client.get("/oauth/authorize").status_code != 401
-        assert client.post("/oauth/token", data={"grant_type": "authorization_code"}).status_code != 401
-        assert client.post("/oauth/revoke", data={"token": "x"}).status_code != 401
-        assert client.post("/oauth/register", json={"redirect_uris": [REDIRECT_URI]}).status_code != 401
+        # Malformed inputs: the handlers must run and answer 4xx themselves,
+        # not be short-circuited by auth (401/403) or crash (5xx).
+        for response in (
+            client.get("/oauth/authorize"),
+            client.post("/oauth/authorize", data={"action": "login"}, headers={"Origin": ISSUER}),
+            client.post("/oauth/token", data={"grant_type": "authorization_code"}),
+            client.post("/oauth/revoke", data={"token": "x"}),
+            client.post("/oauth/register", json={"redirect_uris": ["javascript:alert(1)"]}),
+        ):
+            assert response.status_code not in (401, 403), response.text
+            assert response.status_code < 500, response.text

--- a/python/django_bolt/_kwargs/extractors.py
+++ b/python/django_bolt/_kwargs/extractors.py
@@ -16,7 +16,6 @@ import msgspec
 from ..concurrency import run_in_orm_executor
 from ..datastructures import UploadFile
 from ..exceptions import HTTPException, RequestValidationError, parse_msgspec_decode_error
-from ..pagination import PaginatedResponse
 from ..typing import (
     FieldDefinition,
     HandlerMetadata,
@@ -827,9 +826,9 @@ def coerce_to_response_type(value: Any, annotation: Any, meta: HandlerMetadata |
     Returns:
         Coerced value
     """
-    # Skip validation for PaginatedResponse - pagination decorator handles serialization
-    # PaginatedResponse is a msgspec.Struct that serializes directly
-    if isinstance(value, PaginatedResponse):
+    # A Struct instance of the annotated (possibly parametrized) struct type —
+    # e.g. a pagination envelope ``PaginatedResponse[Item]`` — serializes as-is.
+    if isinstance(value, msgspec.Struct) and (get_origin(annotation) or annotation) is type(value):
         return value
 
     # Handle Django QuerySets - convert to list using .values()

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -549,6 +549,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "GET",
@@ -563,6 +564,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def post(
@@ -579,6 +581,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "POST",
@@ -593,6 +596,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def put(
@@ -609,6 +613,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "PUT",
@@ -623,6 +628,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def patch(
@@ -639,6 +645,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "PATCH",
@@ -653,6 +660,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def delete(
@@ -669,6 +677,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "DELETE",
@@ -683,6 +692,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def head(
@@ -699,6 +709,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "HEAD",
@@ -713,6 +724,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def options(
@@ -729,6 +741,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "OPTIONS",
@@ -743,6 +756,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def query(
@@ -759,6 +773,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
     ):
         return self._route_decorator(
             "QUERY",
@@ -773,6 +788,7 @@ class BoltAPI:
             summary=summary,
             description=description,
             response_class=response_class,
+            include_in_schema=include_in_schema,
         )
 
     def websocket(
@@ -1366,6 +1382,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
+        include_in_schema: bool = True,
         _name_explicit: bool = True,
         _skip_prefix: bool = False,
         _router_middleware: list[Any] | None = None,
@@ -1524,6 +1541,7 @@ class BoltAPI:
                 meta["response_type"] = None
             meta["validate_response"] = route_validate_response
             meta["response_class"] = response_class
+            meta["include_in_schema"] = include_in_schema
             # Pre-compute stream annotation analysis (registration time only)
             meta["_stream_info"] = _extract_stream_item_type(meta["response_type"])
 
@@ -1537,6 +1555,9 @@ class BoltAPI:
                     original = getattr(fn, "__original_handler__", None)
                     if original is not None:
                         original.__serializer_class__ = item_type
+                    # The wire shape is the pagination envelope, not the item
+                    # list: validate and document ``response_class[item]``.
+                    meta["response_type"] = fn.__pagination_class__.response_class[item_type]
 
             # Guarantee all keys exist at registration time for direct access
             if meta["is_multi_response"]:

--- a/python/django_bolt/openapi/config.py
+++ b/python/django_bolt/openapi/config.py
@@ -161,6 +161,17 @@ class OpenAPIConfig:
         ```
     """
 
+    strict: bool = field(default=False)
+    """Fail schema generation on shapes codegen cannot type.
+
+    When True, ``SchemaGenerator.generate`` raises ``OpenAPIStrictError`` (listing
+    every offender) if any route documents an opaque ``{"type": "object"}`` JSON
+    response (no return annotation / ``response_model``) or any component name
+    had to fall back to ``module.qualname`` because two types share a short name.
+    Routes with ``include_in_schema=False`` and non-JSON ``response_class`` routes
+    are not offenders.
+    """
+
     enabled: bool = field(default=True)
     """Enable or disable OpenAPI documentation.
 

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -974,7 +974,9 @@ class SchemaGenerator:
             required=True,
         )
 
-    def _extract_responses(self, meta: dict[str, Any], handler_id: int, *, method: str = "", path: str = "") -> dict[str, OpenAPIResponse]:
+    def _extract_responses(
+        self, meta: dict[str, Any], handler_id: int, *, method: str = "", path: str = ""
+    ) -> dict[str, OpenAPIResponse]:
         """Extract OpenAPI responses from handler metadata.
 
         Args:

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -12,6 +12,15 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_args, get_
 import msgspec
 
 from ..datastructures import UploadFile
+from ..responses import (
+    HTML,
+    EventSourceResponse,
+    File,
+    FileResponse,
+    PlainText,
+    Redirect,
+    StreamingResponse,
+)
 from ..serializers.fields import _FieldMarker
 from ..typing import is_msgspec_struct, is_optional, unwrap_optional
 from .spec import (
@@ -34,7 +43,55 @@ if TYPE_CHECKING:
     from ..api import BoltAPI
     from .config import OpenAPIConfig
 
-__all__ = ("ComponentNameCollisionError", "SchemaGenerator")
+__all__ = ("ComponentNameCollisionError", "OpenAPIStrictError", "SchemaGenerator")
+
+
+class OpenAPIStrictError(ValueError):
+    """``OpenAPIConfig(strict=True)``: the schema would contain shapes codegen cannot type.
+
+    Raised by ``SchemaGenerator.generate`` with every offender listed at once:
+    routes whose success response is an opaque ``{"type": "object"}`` (no return
+    annotation / ``response_model``) and components that needed the
+    ``module.qualname`` fallback because two types share a short name.
+    """
+
+
+# ``response_class`` → (media type, body schema). ``Redirect`` is handled
+# separately (3xx, no body). Order matters: subclasses before their bases.
+_RESPONSE_CLASS_MEDIA: tuple[tuple[type, str, Schema], ...] = (
+    (HTML, "text/html", Schema(type="string")),
+    (PlainText, "text/plain", Schema(type="string")),
+    (EventSourceResponse, "text/event-stream", Schema(type="string")),
+    (StreamingResponse, "application/octet-stream", Schema(type="string", format="binary")),
+    (File, "application/octet-stream", Schema(type="string", format="binary")),
+    (FileResponse, "application/octet-stream", Schema(type="string", format="binary")),
+)
+
+
+def _response_class_media(response_class: type | None) -> tuple[str, Schema] | None:
+    if response_class is None:
+        return None
+    for cls, media_type, schema in _RESPONSE_CLASS_MEDIA:
+        if issubclass(response_class, cls):
+            return media_type, schema
+    return None
+
+
+def _struct_origin(annotation: Any) -> type | None:
+    """The msgspec.Struct class behind ``annotation`` — itself, or the origin of ``Struct[T]``."""
+    if is_msgspec_struct(annotation):
+        return annotation
+    origin = get_origin(annotation)
+    return origin if is_msgspec_struct(origin) else None
+
+
+def _type_display_name(annotation: Any) -> str:
+    """``Page[UserRead]`` for a parametrized struct, ``__name__`` otherwise (msgspec's title)."""
+    origin = get_origin(annotation)
+    if origin is not None and get_args(annotation):
+        args = ", ".join(_type_display_name(a) for a in get_args(annotation))
+        return f"{getattr(origin, '__name__', repr(origin))}[{args}]"
+    return getattr(annotation, "__name__", None) or repr(annotation)
 
 
 class ComponentNameCollisionError(ValueError):
@@ -231,6 +288,9 @@ class SchemaGenerator:
         # registration order the name map iterates.
         self._component_ref: dict[type, Reference] = {}
         self._component_schema: dict[type, Schema] = {}
+        # strict mode bookkeeping (see OpenAPIStrictError)
+        self._opaque_operations: list[str] = []
+        self._qualified_components: list[str] = []
 
     @staticmethod
     def _schema_kwargs(**kwargs: Any) -> dict[str, Any]:
@@ -460,11 +520,13 @@ class SchemaGenerator:
             if should_exclude:
                 continue
 
-            if path not in paths:
-                paths[path] = PathItem()
-
             # Get handler metadata
             meta = self.api._handler_meta.get(handler_id, {})
+            if not meta.get("include_in_schema", True):
+                continue
+
+            if path not in paths:
+                paths[path] = PathItem()
 
             # Create operation
             operation = self._create_operation(
@@ -547,6 +609,20 @@ class SchemaGenerator:
         # Collect and merge tags
         openapi.tags = self._collect_tags(collected_tags)
 
+        if self.config.strict and (self._opaque_operations or self._qualified_components):
+            problems = []
+            if self._opaque_operations:
+                problems.append(
+                    "routes with an untyped JSON response (add a return annotation or response_model): "
+                    + ", ".join(self._opaque_operations)
+                )
+            if self._qualified_components:
+                problems.append(
+                    "component names that fell back to module.qualname because two types share a "
+                    "short name (rename one): " + ", ".join(self._qualified_components)
+                )
+            raise OpenAPIStrictError("OpenAPI strict mode: " + "; ".join(problems))
+
         return openapi
 
     def _create_operation(
@@ -581,7 +657,7 @@ class SchemaGenerator:
         request_body = self._extract_request_body(meta)
 
         # Extract responses (pass handler_id for auth error responses)
-        responses = self._extract_responses(meta, handler_id)
+        responses = self._extract_responses(meta, handler_id, method=method, path=path)
 
         # Extract security requirements
         security = self._extract_security(handler_id)
@@ -898,7 +974,7 @@ class SchemaGenerator:
             required=True,
         )
 
-    def _extract_responses(self, meta: dict[str, Any], handler_id: int) -> dict[str, OpenAPIResponse]:
+    def _extract_responses(self, meta: dict[str, Any], handler_id: int, *, method: str = "", path: str = "") -> dict[str, OpenAPIResponse]:
         """Extract OpenAPI responses from handler metadata.
 
         Args:
@@ -952,8 +1028,26 @@ class SchemaGenerator:
             response_type = meta.get("response_type")
             default_status = meta.get("default_status_code", 200)
 
-            # Add successful response
-            if response_type and response_type != inspect._empty:
+            response_class = meta.get("response_class")
+            has_type = bool(response_type) and response_type != inspect._empty
+            media = _response_class_media(response_class)
+
+            if response_class is not None and issubclass(response_class, Redirect):
+                # A redirect has no body; the default 200 is meaningless here.
+                status = default_status if default_status != 200 else 307
+                responses[str(status)] = OpenAPIResponse(
+                    description=http.client.responses.get(status, "Redirect"),
+                    headers={"Location": OpenAPIHeader(schema=Schema(type="string"))},
+                )
+            elif media is not None:
+                media_type, body_schema = media
+                if has_type:
+                    body_schema = self._type_to_schema(response_type, register_component=True)
+                responses[str(default_status)] = OpenAPIResponse(
+                    description="Successful response",
+                    content={media_type: OpenAPIMediaType(schema=body_schema)},
+                )
+            elif has_type:
                 schema = self._type_to_schema(response_type, register_component=True)
 
                 responses[str(default_status)] = OpenAPIResponse(
@@ -966,7 +1060,8 @@ class SchemaGenerator:
                     },
                 )
             else:
-                # Default response
+                # Opaque JSON: nothing to type. Recorded for strict mode.
+                self._opaque_operations.append(f"{method} {path}")
                 responses["200"] = OpenAPIResponse(
                     description="Successful response",
                     content={
@@ -1324,8 +1419,9 @@ class SchemaGenerator:
         if type_annotation is UploadFile:
             return Schema(type="string", format="binary")
 
-        # Handle msgspec.Struct
-        if is_msgspec_struct(type_annotation):
+        # Handle msgspec.Struct — bare or parametrized (``Page[UserRead]``, keyed
+        # and named per parametrization like msgspec: ``Page_UserRead_``).
+        if _struct_origin(type_annotation) is not None:
             if register_component:
                 return self._struct_to_component_schema(type_annotation)
             else:
@@ -1435,9 +1531,9 @@ class SchemaGenerator:
         # _own_docstring — avoids inheriting msgspec.Struct's base docstring).
         # Matches `msgspec.json.schema_components` behavior.
         return Schema(
-            title=struct_type.__name__,
+            title=_type_display_name(struct_type),
             type="object",
-            description=self._own_docstring(struct_type),
+            description=self._own_docstring(_struct_origin(struct_type) or struct_type),
             properties=properties,
             required=required or None,
         )
@@ -1508,7 +1604,9 @@ class SchemaGenerator:
             return re.sub(r"[^a-zA-Z0-9.\-_]", "_", name)
 
         def fullname(cls: type) -> str:
-            return normalize(f"{cls.__module__}.{cls.__qualname__}")
+            origin = get_origin(cls) or cls
+            display = _type_display_name(cls)
+            return normalize(f"{origin.__module__}.{display.replace(origin.__name__, origin.__qualname__, 1)}")
 
         # First map name -> type, expanding only the names that actually collide.
         names: dict[str, type] = {}
@@ -1524,7 +1622,7 @@ class SchemaGenerator:
             names[name] = cls
 
         for cls in self._component_ref:
-            short = normalize(cls.__name__)
+            short = normalize(_type_display_name(cls))
             if short in names and names[short] is not cls:
                 # First collision on this short name: re-home the incumbent under
                 # its qualified name and mark the short name as conflicted.
@@ -1535,6 +1633,8 @@ class SchemaGenerator:
                 assign(fullname(cls), cls)
             else:
                 assign(short, cls)
+
+        self._qualified_components = [fullname(names[n]) for n in sorted(names) if n not in conflicts and "." in n]
 
         # Stamp each shared Reference and publish the schema under its final name.
         for name, cls in names.items():

--- a/python/django_bolt/pagination.py
+++ b/python/django_bolt/pagination.py
@@ -27,7 +27,7 @@ import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar, get_args, get_origin
+from typing import Any, Generic, TypeVar, get_args, get_origin
 
 import msgspec
 
@@ -49,7 +49,7 @@ T = TypeVar("T")
 _PAGINATION_UNSET = object()
 
 
-class PaginatedResponse[T](msgspec.Struct, omit_defaults=True):
+class PaginatedResponse(msgspec.Struct, Generic[T], omit_defaults=True):  # noqa: UP046 — PEP 695 params are unresolvable under PEP 563
     """
     Standard paginated response structure.
 
@@ -144,6 +144,29 @@ class PaginationBase(ABC):
     # Serializer class for item serialization (set at runtime by paginate wrapper)
     serializer_class: type | None = None
 
+    # Envelope type: a generic msgspec.Struct/Serializer taking the item type
+    # (``response_class[Item]``). Drives the OpenAPI schema and response
+    # validation; override together with build_response() for a custom shape.
+    response_class: type = PaginatedResponse
+
+    def build_response(
+        self,
+        items: list[Any],
+        *,
+        total: int,
+        request: Any,
+        has_next: bool,
+        has_previous: bool,
+        **info: Any,
+    ) -> Any:
+        """Build the envelope for one page.
+
+        ``info`` carries the scheme-specific fields (page/page_size/total_pages/
+        next_page/previous_page, limit/offset, next_cursor/previous_cursor).
+        Override to return an instance of a custom ``response_class``.
+        """
+        return self.response_class(items=items, total=total, has_next=has_next, has_previous=has_previous, **info)
+
     @abstractmethod
     async def get_page_params(self, request: dict[str, Any]) -> dict[str, Any]:
         """
@@ -158,7 +181,7 @@ class PaginationBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> PaginatedResponse:
+    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> Any:
         """
         Apply pagination to a queryset and return paginated response.
 
@@ -238,18 +261,6 @@ class PaginationBase(ABC):
         if getattr(self.serializer_class, "__is_bolt_serializer__", False):
             serializer_class = self.serializer_class
             serializer_class._ensure_from_model_ready()
-            can_use_sync_from_model = not any(
-                spec.nested is not None or (spec.source is not None and "." in spec.source)
-                for spec in serializer_class.__model_field_specs__
-            )
-
-            if can_use_sync_from_model:
-                try:
-                    serializer_instances = [serializer_class.from_model(item) for item in items]
-                except Exception:
-                    serializer_instances = None
-                else:
-                    return serializer_class.dump_many(serializer_instances)
 
             try:
                 serializer_instances = [serializer_class.from_model(item) for item in items]
@@ -289,6 +300,11 @@ class PaginationBase(ABC):
         # sync_to_async(thread_sensitive=True) hop onto one shared thread —
         # both per-chunk overhead AND a cross-request serialization point.
         if hasattr(queryset, "_iterable_class") and hasattr(queryset, "model"):
+            serializer_class = self.serializer_class
+            if getattr(serializer_class, "__is_bolt_serializer__", False):
+                # Pre-load what the item serializer reads (select_related /
+                # prefetch_related / annotate) so a page never costs N+1.
+                queryset = serializer_class._prepare_queryset(queryset)
             return await run_in_orm_executor(list, queryset)
         # Non-QuerySet async iterables (has __aiter__)
         if hasattr(queryset, "__aiter__"):
@@ -390,7 +406,7 @@ class PageNumberPagination(PaginationBase):
 
         return {"page": page, "page_size": page_size}
 
-    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> PaginatedResponse:
+    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> Any:
         """
         Paginate queryset using page numbers.
 
@@ -426,14 +442,15 @@ class PageNumberPagination(PaginationBase):
         items = await self._serialize_items(raw_items)
 
         # Build response
-        return PaginatedResponse(
-            items=items,
+        return self.build_response(
+            items,
             total=total,
+            request=request,
+            has_next=page_number < total_pages,
+            has_previous=page_number > 1,
             page=page_number,
             page_size=page_size,
             total_pages=total_pages,
-            has_next=page_number < total_pages,
-            has_previous=page_number > 1,
             next_page=page_number + 1 if page_number < total_pages else None,
             previous_page=page_number - 1 if page_number > 1 else None,
         )
@@ -488,7 +505,7 @@ class LimitOffsetPagination(PaginationBase):
 
         return {"limit": limit, "offset": offset}
 
-    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> PaginatedResponse:
+    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> Any:
         """
         Paginate queryset using limit/offset.
 
@@ -517,13 +534,14 @@ class LimitOffsetPagination(PaginationBase):
         has_next = (offset + limit) < total
         has_previous = offset > 0
 
-        return PaginatedResponse(
-            items=items,
+        return self.build_response(
+            items,
             total=total,
-            limit=limit,
-            offset=offset,
+            request=request,
             has_next=has_next,
             has_previous=has_previous,
+            limit=limit,
+            offset=offset,
         )
 
 
@@ -596,7 +614,7 @@ class CursorPagination(PaginationBase):
 
         return {"cursor": cursor_value, "page_size": page_size}
 
-    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> PaginatedResponse:
+    async def paginate_queryset(self, queryset: Any, request: dict[str, Any], **params: Any) -> Any:
         """
         Paginate queryset using cursor-based pagination.
 
@@ -655,12 +673,13 @@ class CursorPagination(PaginationBase):
         # Serialize items using efficient batch serialization
         items = await self._serialize_items(raw_items)
 
-        return PaginatedResponse(
-            items=items,
+        return self.build_response(
+            items,
             total=0,  # Cursor pagination doesn't provide total count for efficiency
-            page_size=page_size,
+            request=request,
             has_next=has_next,
             has_previous=cursor_value is not None,
+            page_size=page_size,
             next_cursor=next_cursor,
         )
 

--- a/python/django_bolt/serialization.py
+++ b/python/django_bolt/serialization.py
@@ -422,15 +422,18 @@ def _compile_serializer_values_evaluators(serializer_cls: Any) -> tuple[Any, Any
     model_ok: dict[type, bool] = {}
 
     def evaluate_sync(queryset: QuerySet) -> list[Any]:
+        queryset = serializer_cls._prepare_queryset(queryset)  # Config.annotations & co.
         ok = model_ok.get(queryset.model)
         if ok is False:
-            return list(queryset)
+            # Project here, on the ORM thread, so model properties may still
+            # query (an N+1, never SynchronousOnlyOperation on the loop).
+            return _dump_many_sync(serializer_cls, list(queryset), False)
         try:
             items = list(queryset.values(*field_names))
         except FieldError:
             # Serializer field isn't a concrete column on this model.
             model_ok[queryset.model] = False
-            return list(queryset)
+            return _dump_many_sync(serializer_cls, list(queryset), False)
         model_ok[queryset.model] = True
         return items
 
@@ -824,7 +827,21 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
     stream_info = meta.get("_stream_info", (False, None))
     response_class = meta.get("response_class")
 
-    is_serializer_response = _response_serializer_info(meta.get("response_type"))[0] is not None
+    _serializer_cls, _serializer_many = _response_serializer_info(meta.get("response_type"))
+    is_serializer_response = _serializer_cls is not None
+    # list[Serializer] routes returning a QuerySet: pre-load what the serializer
+    # reads (select_related/prefetch_related/annotate from its fields), then
+    # from_model + dump. Async routes iterate with the async ORM on the loop.
+    if _serializer_many:
+
+        def evaluate_serializer_queryset(queryset: QuerySet) -> list[Any]:
+            return _serializer_cls.dump_many(_serializer_cls.from_models(queryset))
+
+        async def evaluate_serializer_queryset_async(queryset: QuerySet) -> list[Any]:
+            return _serializer_cls.dump_many(await _serializer_cls.afrom_models(queryset))
+
+    else:
+        evaluate_serializer_queryset = evaluate_serializer_queryset_async = None
 
     def prepare_list(result: list[Any]) -> Any:
         if is_serializer_response:
@@ -866,6 +883,10 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, QuerySet):
             if queryset_serializer_async is not None:
                 result = await queryset_serializer_async(result)
+            elif evaluate_serializer_queryset_async is not None:
+                # Already dumped dicts — nothing left for the validator to do.
+                result = await evaluate_serializer_queryset_async(result)
+                return await _serialize_json_payload_async(result, current_status, None)
             else:
                 # Bounded ORM pool — parallel, but capped connection count.
                 result = await run_in_orm_executor(list, result)
@@ -903,7 +924,12 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
             return _serialize_json_payload_sync(result, current_status, validator_sync)
 
         if isinstance(result, QuerySet):
-            result = queryset_serializer_sync(result) if queryset_serializer_sync is not None else list(result)
+            if queryset_serializer_sync is not None:
+                result = queryset_serializer_sync(result)
+            elif evaluate_serializer_queryset is not None:
+                return _serialize_json_payload_sync(evaluate_serializer_queryset(result), current_status, None)
+            else:
+                result = list(result)
             return _serialize_json_payload_sync(result, current_status, validator_sync)
 
         if isinstance(result, msgspec.Struct) or validator_sync is not None:

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -38,7 +38,11 @@ from msgspec import ValidationError as MsgspecValidationError
 from msgspec import structs as msgspec_structs
 
 from django_bolt import _json
-from django_bolt.exceptions import RequestValidationError, SerializationError, UnloadedRelationError
+from django_bolt.exceptions import (
+    RequestValidationError,
+    SerializationError,
+    UnloadedRelationError,
+)
 
 from .decorators import (
     ComputedFieldConfig,
@@ -47,6 +51,7 @@ from .decorators import (
     collect_model_validators,
 )
 from .fields import FieldConfig, _FieldMarker
+from .loading import LoadingPlan, build_loading_plan
 from .nested import resolve_nested_config, validate_nested_field
 
 # Regex to extract field path from msgspec error messages (e.g., "at `$.field_name`")
@@ -478,6 +483,9 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         )
 
         cls.__default_values_map__ = None
+        # A subclass must rebuild its own specs even when the parent already
+        # collected (otherwise it inherits ``True`` and dumps ``{}``).
+        cls.__field_configs_collected__ = False
         cls._dump_field_specs = ()
         cls._dump_field_spec_cache = {}
         cls._computed_dump_spec_cache = {}
@@ -1686,6 +1694,41 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             data[spec.field_name] = value
 
         return cls(**data)
+
+    @classmethod
+    def loading_plan(cls, model_cls: type[Model]) -> LoadingPlan:
+        """The ORM loads (select_related/prefetch_related/annotate) this serializer needs from ``model_cls``."""
+        return build_loading_plan(cls, model_cls)
+
+    @classmethod
+    def _prepare_queryset(cls, queryset: QuerySet) -> QuerySet:
+        """Apply this serializer's loading plan to ``queryset`` (additive, idempotent)."""
+        return build_loading_plan(cls, queryset.model).apply(queryset)
+
+    @classmethod
+    def from_models(cls: type[T], objects: QuerySet | Iterable[Model]) -> list[T]:
+        """Build one serializer instance per model in ``objects``.
+
+        A QuerySet is first prepared with this serializer's loading plan —
+        FK/O2O → ``select_related``, M2M/reverse → ``prefetch_related`` (nested
+        serializers recurse), ``Config.annotations`` → ``annotate`` — so the
+        whole batch costs a bounded number of queries; loads the caller already
+        requested are kept. Any other iterable of instances is used as-is.
+
+        Bolt does this automatically for routes annotated ``list[ThisSerializer]``
+        that return a QuerySet; call it when you evaluate the queryset yourself.
+        Use :meth:`afrom_models` from async code.
+        """
+        if isinstance(objects, QuerySet):
+            objects = cls._prepare_queryset(objects)
+        return [cls.from_model(obj) for obj in objects]
+
+    @classmethod
+    async def afrom_models(cls: type[T], objects: QuerySet | Iterable[Model]) -> list[T]:
+        """Async :meth:`from_models`: iterates the prepared QuerySet with the async ORM."""
+        if isinstance(objects, QuerySet):
+            return [cls.from_model(obj) async for obj in cls._prepare_queryset(objects)]
+        return [cls.from_model(obj) for obj in objects]
 
     @classmethod
     async def afrom_model(

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -1725,7 +1725,13 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
 
     @classmethod
     async def afrom_models(cls: type[T], objects: QuerySet | Iterable[Model]) -> list[T]:
-        """Async :meth:`from_models`: iterates the prepared QuerySet with the async ORM."""
+        """Async :meth:`from_models`: iterates the prepared QuerySet with the async ORM.
+
+        Rows are converted with the sync :meth:`from_model`, so relations the
+        loading plan cannot cover are *not* lazily loaded (unlike
+        :meth:`afrom_model`): a required nested field left unloaded raises
+        ``UnloadedRelationError`` — add the load to the queryset instead.
+        """
         if isinstance(objects, QuerySet):
             return [cls.from_model(obj) async for obj in cls._prepare_queryset(objects)]
         return [cls.from_model(obj) for obj in objects]

--- a/python/django_bolt/serializers/loading.py
+++ b/python/django_bolt/serializers/loading.py
@@ -11,8 +11,8 @@ turns that into the ORM calls that load it in a bounded number of queries:
 - Django >= 6.1: ``fetch_mode(FETCH_PEERS)`` as a safety net for anything not
   declared (e.g. a model ``@property`` reading a FK)
 
-Plans are built once per ``(serializer, model)`` and cached weakly by model class
-so dev reloads don't pin stale classes.
+Plans are built once per ``(serializer, model)``; the cache holds both classes
+weakly so dev reloads don't pin stale classes.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 from weakref import WeakKeyDictionary
 
 from django.db.models import Prefetch, QuerySet
+from django.db.models.query import ModelIterable
 
 try:  # Django >= 6.1
     from django.db.models import FETCH_ONE, FETCH_PEERS
@@ -51,7 +52,11 @@ class LoadingPlan:
         Additive and idempotent: relations the caller already loads are kept
         (``select_related`` merges; a prefetch lookup already present is not
         added again), annotations already on the query are not overwritten.
+        A ``values()``/``values_list()`` queryset yields rows, not model
+        instances — there is nothing to load onto, so it is returned unchanged.
         """
+        if not issubclass(queryset._iterable_class, ModelIterable):
+            return queryset
         if self.select_related:
             queryset = queryset.select_related(*self.select_related)
         if self.prefetch:
@@ -73,14 +78,14 @@ def _prefetch_lookup(lookup: str | Prefetch) -> str:
     return lookup.prefetch_to if isinstance(lookup, Prefetch) else lookup
 
 
-_PLAN_CACHE: WeakKeyDictionary[type, dict[type, LoadingPlan]] = WeakKeyDictionary()
+_PLAN_CACHE: WeakKeyDictionary[type, WeakKeyDictionary[type, LoadingPlan]] = WeakKeyDictionary()
 
 
 def build_loading_plan(serializer_cls: type[Serializer], model_cls: type) -> LoadingPlan:
     """Build (or fetch the cached) loading plan for ``serializer_cls`` over ``model_cls``."""
     per_model = _PLAN_CACHE.get(model_cls)
     if per_model is None:
-        per_model = _PLAN_CACHE[model_cls] = {}
+        per_model = _PLAN_CACHE[model_cls] = WeakKeyDictionary()
     plan = per_model.get(serializer_cls)
     if plan is None:
         # Guard against recursion (Author.posts -> Post.author -> ...): publish an
@@ -127,6 +132,8 @@ def _build(serializer_cls: type[Serializer], model_cls: type) -> LoadingPlan:
                 add_prefetch(Prefetch(lookup, queryset=nested_qs) if nested_qs is not None else lookup)
                 break  # cannot select_related through a many-valued relation
 
+            if is_last and nested is None and info.kind == "forward_one":
+                break  # from_model reads the FK id (attname); the related row is never touched
             select_related.append(lookup)
             if nested is not None:
                 nested_plan = build_loading_plan(nested.serializer_class, info.related_model)

--- a/python/django_bolt/serializers/loading.py
+++ b/python/django_bolt/serializers/loading.py
@@ -1,0 +1,148 @@
+"""Derive a queryset loading plan from a Serializer's declared fields.
+
+A Serializer says *what* it reads from a model (columns, FK/O2O relations,
+M2M/reverse relations, nested serializers, ``Config.annotations``). This module
+turns that into the ORM calls that load it in a bounded number of queries:
+
+- single-valued relations (``forward_one`` / ``reverse_one``) → ``select_related``
+- many-valued relations (``many``) → ``prefetch_related`` (with a nested
+  ``Prefetch`` queryset when the field is a nested Serializer list)
+- ``Config.annotations`` → ``annotate``
+- Django >= 6.1: ``fetch_mode(FETCH_PEERS)`` as a safety net for anything not
+  declared (e.g. a model ``@property`` reading a FK)
+
+Plans are built once per ``(serializer, model)`` and cached weakly by model class
+so dev reloads don't pin stale classes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from weakref import WeakKeyDictionary
+
+from django.db.models import Prefetch, QuerySet
+
+try:  # Django >= 6.1
+    from django.db.models import FETCH_ONE, FETCH_PEERS
+except ImportError:  # pragma: no cover - older Django
+    FETCH_ONE = FETCH_PEERS = None
+
+if TYPE_CHECKING:
+    from .base import Serializer
+
+__all__ = ("LoadingPlan", "build_loading_plan")
+
+
+@dataclass(frozen=True)
+class LoadingPlan:
+    """The ORM calls a Serializer needs to load its fields without extra queries."""
+
+    select_related: tuple[str, ...] = ()
+    prefetch: tuple[str | Prefetch, ...] = ()
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return bool(self.select_related or self.prefetch or self.annotations)
+
+    def apply(self, queryset: QuerySet) -> QuerySet:
+        """Return ``queryset`` with this plan applied.
+
+        Additive and idempotent: relations the caller already loads are kept
+        (``select_related`` merges; a prefetch lookup already present is not
+        added again), annotations already on the query are not overwritten.
+        """
+        if self.select_related:
+            queryset = queryset.select_related(*self.select_related)
+        if self.prefetch:
+            existing = {_prefetch_lookup(lookup) for lookup in queryset._prefetch_related_lookups}
+            missing = [lookup for lookup in self.prefetch if _prefetch_lookup(lookup) not in existing]
+            if missing:
+                queryset = queryset.prefetch_related(*missing)
+        if self.annotations:
+            present = queryset.query.annotations
+            missing_annotations = {k: v for k, v in self.annotations.items() if k not in present}
+            if missing_annotations:
+                queryset = queryset.annotate(**missing_annotations)
+        if FETCH_PEERS is not None and queryset._fetch_mode is FETCH_ONE:
+            queryset = queryset.fetch_mode(FETCH_PEERS)
+        return queryset
+
+
+def _prefetch_lookup(lookup: str | Prefetch) -> str:
+    return lookup.prefetch_to if isinstance(lookup, Prefetch) else lookup
+
+
+_PLAN_CACHE: WeakKeyDictionary[type, dict[type, LoadingPlan]] = WeakKeyDictionary()
+
+
+def build_loading_plan(serializer_cls: type[Serializer], model_cls: type) -> LoadingPlan:
+    """Build (or fetch the cached) loading plan for ``serializer_cls`` over ``model_cls``."""
+    per_model = _PLAN_CACHE.get(model_cls)
+    if per_model is None:
+        per_model = _PLAN_CACHE[model_cls] = {}
+    plan = per_model.get(serializer_cls)
+    if plan is None:
+        # Guard against recursion (Author.posts -> Post.author -> ...): publish an
+        # empty plan first; a cycle stops at the already-declared level.
+        per_model[serializer_cls] = LoadingPlan()
+        plan = per_model[serializer_cls] = _build(serializer_cls, model_cls)
+    return plan
+
+
+def _build(serializer_cls: type[Serializer], model_cls: type) -> LoadingPlan:
+    from .base import _get_django_relation_info  # noqa: PLC0415 - avoid import cycle
+
+    serializer_cls._ensure_from_model_ready()
+    select_related: list[str] = []
+    prefetch: list[str | Prefetch] = []
+    seen_prefetch: set[str] = set()
+
+    def add_prefetch(lookup: str | Prefetch) -> None:
+        name = _prefetch_lookup(lookup)
+        if name not in seen_prefetch:
+            seen_prefetch.add(name)
+            prefetch.append(lookup)
+
+    for spec in serializer_cls.__model_field_specs__:
+        source = spec.source or spec.field_name
+        parts = source.split(".")
+        current_model = model_cls
+        path: list[str] = []
+        for index, part in enumerate(parts):
+            info = _get_django_relation_info(current_model, part)
+            if info is None or info.related_model is None:
+                break  # column, property, method: nothing to load
+            path.append(part)
+            lookup = "__".join(path)
+            is_last = index == len(parts) - 1
+            nested = spec.nested if is_last else None
+
+            if info.kind == "many":
+                nested_qs = None
+                if nested is not None:
+                    nested_plan = build_loading_plan(nested.serializer_class, info.related_model)
+                    if nested_plan:
+                        nested_qs = nested_plan.apply(info.related_model._default_manager.all())
+                add_prefetch(Prefetch(lookup, queryset=nested_qs) if nested_qs is not None else lookup)
+                break  # cannot select_related through a many-valued relation
+
+            select_related.append(lookup)
+            if nested is not None:
+                nested_plan = build_loading_plan(nested.serializer_class, info.related_model)
+                select_related.extend(f"{lookup}__{rel}" for rel in nested_plan.select_related)
+                for nested_lookup in nested_plan.prefetch:
+                    if isinstance(nested_lookup, Prefetch):
+                        add_prefetch(Prefetch(f"{lookup}__{nested_lookup.prefetch_to}", queryset=nested_lookup.queryset))
+                    else:
+                        add_prefetch(f"{lookup}__{nested_lookup}")
+            current_model = info.related_model
+
+    config = getattr(serializer_cls, "Config", None)
+    annotations = dict(getattr(config, "annotations", None) or {})
+
+    return LoadingPlan(
+        select_related=tuple(dict.fromkeys(select_related)),
+        prefetch=tuple(prefetch),
+        annotations=annotations,
+    )

--- a/python/django_bolt/serializers/loading.py
+++ b/python/django_bolt/serializers/loading.py
@@ -140,7 +140,9 @@ def _build(serializer_cls: type[Serializer], model_cls: type) -> LoadingPlan:
                 select_related.extend(f"{lookup}__{rel}" for rel in nested_plan.select_related)
                 for nested_lookup in nested_plan.prefetch:
                     if isinstance(nested_lookup, Prefetch):
-                        add_prefetch(Prefetch(f"{lookup}__{nested_lookup.prefetch_to}", queryset=nested_lookup.queryset))
+                        add_prefetch(
+                            Prefetch(f"{lookup}__{nested_lookup.prefetch_to}", queryset=nested_lookup.queryset)
+                        )
                     else:
                         add_prefetch(f"{lookup}__{nested_lookup}")
             current_model = info.related_model

--- a/python/tests/serializers/test_base.py
+++ b/python/tests/serializers/test_base.py
@@ -506,3 +506,23 @@ class TestModelValidateCollectsAllErrors:
         errors = exc_info.value.errors()
         locs = {tuple(err["loc"]) for err in errors}
         assert ("body", "lastName") in locs
+
+
+def test_subclass_used_after_parent_dumps_all_fields():
+    """A field-less subclass must build its own dump specs even when the parent was
+    used (and lazily collected) first — it used to inherit the parent's 'collected'
+    flag with empty specs and dump ``{}``."""
+
+    class Owner(Serializer):
+        id: int
+
+    class Parent(Serializer):
+        id: int
+        owner: Owner  # nested: forces the spec-driven (non-fast-path) dump
+
+    class Child(Parent):
+        pass
+
+    assert Parent(id=1, owner=Owner(id=9)).dump() == {"id": 1, "owner": {"id": 9}}
+    assert Child(id=2, owner=Owner(id=9)).dump() == {"id": 2, "owner": {"id": 9}}
+    assert Child.dump_many([Child(id=3, owner=Owner(id=9))]) == [{"id": 3, "owner": {"id": 9}}]

--- a/python/tests/serializers/test_loading_plan.py
+++ b/python/tests/serializers/test_loading_plan.py
@@ -270,3 +270,40 @@ def test_paginated_route_applies_plan_to_the_page(blog, count_queries):
     assert items[0]["comments"][0]["author"]["name"] == "Alice"
     # count + page(posts+author) + tags + comments
     assert len(count_queries) == 4
+
+
+# ---------------------------------------------------------------------------
+# Django 6.1: fetch_mode(FETCH_PEERS) as the safety net for anything the plan
+# does not cover (deferred fields, relations behind properties)
+# ---------------------------------------------------------------------------
+
+fetch_modes = pytest.importorskip("django.db.models.fetch_modes", reason="fetch modes need Django >= 6.1")
+
+
+def test_plan_sets_fetch_peers_when_available():
+    qs = PostWithAuthor.loading_plan(BlogPost).apply(BlogPost.objects.all())
+    assert qs._fetch_mode is fetch_modes.FETCH_PEERS
+
+
+def test_plan_keeps_callers_explicit_fetch_mode():
+    qs = BlogPost.objects.fetch_mode(fetch_modes.FETCH_RAISE)
+    assert PostWithAuthor.loading_plan(BlogPost).apply(qs)._fetch_mode is fetch_modes.FETCH_RAISE
+
+
+@pytest.mark.django_db
+def test_fetch_peers_batches_relations_the_plan_cannot_see(blog, django_assert_num_queries):
+    class PostWithAuthorViaProperty(Serializer):
+        id: int
+        author_name: str = field(source="author_display")  # a model property, opaque to the plan
+
+    BlogPost.author_display = property(lambda self: self.author.name)
+    try:
+        assert not PostWithAuthorViaProperty.loading_plan(BlogPost).select_related
+        # posts + ONE peers batch for author (not one query per post)
+        with django_assert_num_queries(2):
+            dumped = PostWithAuthorViaProperty.dump_many(
+                PostWithAuthorViaProperty.from_models(BlogPost.objects.order_by("id"))
+            )
+    finally:
+        del BlogPost.author_display
+    assert [d["author_name"] for d in dumped] == ["Alice"] * 3

--- a/python/tests/serializers/test_loading_plan.py
+++ b/python/tests/serializers/test_loading_plan.py
@@ -17,13 +17,20 @@ from __future__ import annotations
 
 import pytest
 from django.db.backends import utils as db_utils
-from django.db.models import Count, Prefetch
+from django.db.models import Count, F, Prefetch
 
 from django_bolt import BoltAPI
 from django_bolt.pagination import PageNumberPagination, paginate
 from django_bolt.serializers import Serializer, field
 from django_bolt.testing import TestClient
 from tests.test_models import Author, BlogPost, Comment, Tag
+
+try:  # Django >= 6.1
+    from django.db.models import fetch_modes
+except ImportError:  # pragma: no cover
+    fetch_modes = None
+
+needs_fetch_modes = pytest.mark.skipif(fetch_modes is None, reason="fetch modes need Django >= 6.1")
 
 
 class AuthorMini(Serializer):
@@ -84,8 +91,12 @@ def blog(db):
 
 
 @pytest.fixture
-def count_queries(monkeypatch):
-    """Count SQL statements on every thread (the ORM executor uses its own connections)."""
+def count_queries(monkeypatch, blog):
+    """Count SQL statements on every thread (the ORM executor uses its own connections).
+
+    Depends on ``blog`` so the fixture data is inserted before counting starts,
+    whatever order a test lists its parameters in.
+    """
     statements: list[str] = []
     original = db_utils.CursorWrapper._execute
 
@@ -128,6 +139,14 @@ def test_plan_carries_config_annotations():
     assert list(AuthorWithPostCount.loading_plan(Author).annotations) == ["post_count"]
 
 
+def test_plan_skips_join_for_fk_id_only_field():
+    class PostAuthorId(Serializer):
+        id: int
+        author: int  # reads author_id; the related row is never touched
+
+    assert not PostAuthorId.loading_plan(BlogPost)
+
+
 def test_plan_ignores_columns_and_unknown_attributes():
     class Plain(Serializer):
         id: int
@@ -168,6 +187,30 @@ def test_from_models_keeps_callers_loads_and_never_duplicates(blog, django_asser
     with django_assert_num_queries(3):  # posts+author, tags (once), comments
         posts = PostFull.from_models(base)
     assert [p.title for p in posts] == ["Post 0", "Post 1", "Post 2"]
+
+
+@pytest.mark.django_db
+def test_from_models_leaves_values_querysets_alone(blog):
+    """A ``.values()`` queryset yields dicts, not models: no select_related on it (TypeError)."""
+    values_qs = BlogPost.objects.order_by("id").values("id", author_email=F("author__email"))
+    rows = PostWithAuthorEmail._prepare_queryset(values_qs)
+    assert list(rows) == [{"id": p.id, "author_email": "alice@example.com"} for p in blog[1]]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_paginated_values_queryset_still_works(blog, count_queries):
+    api = BoltAPI()
+
+    @api.get("/posts")
+    @paginate(PageNumberPagination)
+    async def list_posts(request) -> list[PostWithAuthorEmail]:
+        return BlogPost.objects.order_by("id").values("id", author_email=F("author__email"))
+
+    with TestClient(api) as client:
+        response = client.get("/posts")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["author_email"] == "alice@example.com"
 
 
 @pytest.mark.django_db
@@ -277,19 +320,21 @@ def test_paginated_route_applies_plan_to_the_page(blog, count_queries):
 # does not cover (deferred fields, relations behind properties)
 # ---------------------------------------------------------------------------
 
-fetch_modes = pytest.importorskip("django.db.models.fetch_modes", reason="fetch modes need Django >= 6.1")
 
 
+@needs_fetch_modes
 def test_plan_sets_fetch_peers_when_available():
     qs = PostWithAuthor.loading_plan(BlogPost).apply(BlogPost.objects.all())
     assert qs._fetch_mode is fetch_modes.FETCH_PEERS
 
 
+@needs_fetch_modes
 def test_plan_keeps_callers_explicit_fetch_mode():
     qs = BlogPost.objects.fetch_mode(fetch_modes.FETCH_RAISE)
     assert PostWithAuthor.loading_plan(BlogPost).apply(qs)._fetch_mode is fetch_modes.FETCH_RAISE
 
 
+@needs_fetch_modes
 @pytest.mark.django_db
 def test_fetch_peers_batches_relations_the_plan_cannot_see(blog, django_assert_num_queries):
     class PostWithAuthorViaProperty(Serializer):

--- a/python/tests/serializers/test_loading_plan.py
+++ b/python/tests/serializers/test_loading_plan.py
@@ -321,7 +321,6 @@ def test_paginated_route_applies_plan_to_the_page(blog, count_queries):
 # ---------------------------------------------------------------------------
 
 
-
 @needs_fetch_modes
 def test_plan_sets_fetch_peers_when_available():
     qs = PostWithAuthor.loading_plan(BlogPost).apply(BlogPost.objects.all())

--- a/python/tests/serializers/test_loading_plan.py
+++ b/python/tests/serializers/test_loading_plan.py
@@ -1,0 +1,272 @@
+"""
+Serializer loading plan (#292 / #295): a Serializer derives the ORM loads it
+needs from its own fields, and Bolt applies them wherever it evaluates a
+QuerySet for that serializer.
+
+- ``Serializer.from_models(qs)`` / ``Serializer.loading_plan(model)``:
+  FK / O2O → ``select_related`` (nested serializers recurse),
+  M2M / reverse FK → ``prefetch_related`` (nested plan inside ``Prefetch``),
+  dotted ``field(source="a.b")`` → ``select_related("a")``,
+  ``Config.annotations`` → ``annotate``.
+- Additive: loads the caller already asked for are kept, never duplicated.
+- Automatic: a ``list[Serializer]`` route (plain or ``@paginate``) returning a
+  bare QuerySet is served with the plan applied — no N+1, no user code.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db.backends import utils as db_utils
+from django.db.models import Count, Prefetch
+
+from django_bolt import BoltAPI
+from django_bolt.pagination import PageNumberPagination, paginate
+from django_bolt.serializers import Serializer, field
+from django_bolt.testing import TestClient
+from tests.test_models import Author, BlogPost, Comment, Tag
+
+
+class AuthorMini(Serializer):
+    id: int
+    name: str
+
+
+class TagMini(Serializer):
+    id: int
+    name: str
+
+
+class CommentWithAuthor(Serializer):
+    id: int
+    text: str
+    author: AuthorMini
+
+
+class PostWithAuthor(Serializer):
+    id: int
+    title: str
+    author: AuthorMini
+
+
+class PostFull(Serializer):
+    id: int
+    title: str
+    author: AuthorMini
+    tags: list[TagMini]
+    comments: list[CommentWithAuthor]
+
+
+class PostWithAuthorEmail(Serializer):
+    id: int
+    author_email: str = field(source="author.email")
+
+
+class AuthorWithPostCount(Serializer):
+    class Config:
+        annotations = {"post_count": Count("posts")}
+
+    id: int
+    name: str
+    post_count: int
+
+
+@pytest.fixture
+def blog(db):
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    tag = Tag.objects.create(name="python")
+    posts = []
+    for i in range(3):
+        post = BlogPost.objects.create(title=f"Post {i}", content="c", author=author)
+        post.tags.add(tag)
+        Comment.objects.create(post=post, author=author, text=f"comment {i}")
+        posts.append(post)
+    return author, posts
+
+
+@pytest.fixture
+def count_queries(monkeypatch):
+    """Count SQL statements on every thread (the ORM executor uses its own connections)."""
+    statements: list[str] = []
+    original = db_utils.CursorWrapper._execute
+
+    def counting_execute(self, sql, params, *ignored_wrapper_args):
+        statements.append(sql)
+        return original(self, sql, params, *ignored_wrapper_args)
+
+    monkeypatch.setattr(db_utils.CursorWrapper, "_execute", counting_execute)
+    return statements
+
+
+# ---------------------------------------------------------------------------
+# Plan derivation
+# ---------------------------------------------------------------------------
+
+
+def test_plan_select_related_for_single_valued_relation():
+    plan = PostWithAuthor.loading_plan(BlogPost)
+    assert plan.select_related == ("author",)
+    assert plan.prefetch == ()
+
+
+def test_plan_prefetch_for_many_valued_relations_with_nested_plan():
+    plan = PostFull.loading_plan(BlogPost)
+    assert plan.select_related == ("author",)
+    lookups = {(p.prefetch_to if isinstance(p, Prefetch) else p) for p in plan.prefetch}
+    assert lookups == {"tags", "comments"}
+    # comments → CommentWithAuthor needs comment.author: nested plan rides inside the Prefetch
+    comments = next(p for p in plan.prefetch if isinstance(p, Prefetch) and p.prefetch_to == "comments")
+    assert comments.queryset.query.select_related == {"author": {}}
+    # tags → TagMini has no relations: plain string lookup, no nested queryset
+    assert "tags" in plan.prefetch
+
+
+def test_plan_follows_dotted_source():
+    assert PostWithAuthorEmail.loading_plan(BlogPost).select_related == ("author",)
+
+
+def test_plan_carries_config_annotations():
+    assert list(AuthorWithPostCount.loading_plan(Author).annotations) == ["post_count"]
+
+
+def test_plan_ignores_columns_and_unknown_attributes():
+    class Plain(Serializer):
+        id: int
+        title: str
+        comment_total: int = field(source="not_a_field")
+
+    plan = Plain.loading_plan(BlogPost)
+    assert not plan
+
+
+# ---------------------------------------------------------------------------
+# from_models(): explicit use
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_from_models_loads_nested_relations_in_bounded_queries(blog, django_assert_num_queries):
+    # posts+author, tags, comments(+author via nested select_related)
+    with django_assert_num_queries(3):
+        dumped = PostFull.dump_many(PostFull.from_models(BlogPost.objects.order_by("id")))
+
+    assert dumped[0]["author"] == {"id": blog[0].id, "name": "Alice"}
+    assert [t["name"] for t in dumped[0]["tags"]] == ["python"]
+    assert dumped[2]["comments"][0]["author"]["name"] == "Alice"
+
+
+@pytest.mark.django_db
+def test_from_models_applies_annotations(blog, django_assert_num_queries):
+    with django_assert_num_queries(1):
+        dumped = AuthorWithPostCount.dump_many(AuthorWithPostCount.from_models(Author.objects.all()))
+    assert dumped == [{"id": blog[0].id, "name": "Alice", "post_count": 3}]
+
+
+@pytest.mark.django_db
+def test_from_models_keeps_callers_loads_and_never_duplicates(blog, django_assert_num_queries):
+    base = BlogPost.objects.prefetch_related("tags").select_related("author").order_by("id")
+
+    with django_assert_num_queries(3):  # posts+author, tags (once), comments
+        posts = PostFull.from_models(base)
+    assert [p.title for p in posts] == ["Post 0", "Post 1", "Post 2"]
+
+
+@pytest.mark.django_db
+def test_from_models_accepts_plain_iterables(blog):
+    posts = PostWithAuthor.from_models(list(BlogPost.objects.select_related("author").order_by("id")))
+    assert [p.author.name for p in posts] == ["Alice"] * 3
+
+
+@pytest.mark.django_db(transaction=True)
+def test_afrom_models_in_async_route(blog, count_queries):
+    api = BoltAPI()
+
+    @api.get("/posts")
+    async def list_posts() -> list[PostFull]:
+        return await PostFull.afrom_models(BlogPost.objects.order_by("id"))
+
+    with TestClient(api) as client:
+        response = client.get("/posts")
+
+    assert response.status_code == 200
+    assert response.json()[0]["comments"][0]["author"]["name"] == "Alice"
+    assert len(count_queries) == 3
+
+
+# ---------------------------------------------------------------------------
+# Automatic: routes and pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+def test_list_route_returning_bare_queryset_is_served_without_n_plus_one(blog, count_queries):
+    api = BoltAPI()
+
+    @api.get("/posts")
+    async def list_posts() -> list[PostFull]:
+        return BlogPost.objects.order_by("id")
+
+    with TestClient(api) as client:
+        response = client.get("/posts")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 3
+    assert body[0]["author"]["name"] == "Alice"
+    assert [t["name"] for t in body[0]["tags"]] == ["python"]
+    assert body[1]["comments"][0]["author"]["name"] == "Alice"
+    assert len(count_queries) == 3  # posts+author, tags, comments+author
+
+
+@pytest.mark.django_db(transaction=True)
+def test_sync_list_route_returning_bare_queryset_is_served_without_n_plus_one(blog, count_queries):
+    api = BoltAPI()
+
+    @api.get("/posts")
+    def list_posts() -> list[PostFull]:
+        return BlogPost.objects.order_by("id")
+
+    with TestClient(api) as client:
+        response = client.get("/posts")
+
+    assert response.status_code == 200
+    assert response.json()[2]["comments"][0]["text"] == "comment 2"
+    assert len(count_queries) == 3
+
+
+@pytest.mark.django_db(transaction=True)
+def test_plain_serializer_route_gets_config_annotations(blog, count_queries):
+    api = BoltAPI()
+
+    @api.get("/authors")
+    async def list_authors() -> list[AuthorWithPostCount]:
+        return Author.objects.all()
+
+    with TestClient(api) as client:
+        response = client.get("/authors")
+
+    assert response.status_code == 200
+    assert response.json() == [{"id": blog[0].id, "name": "Alice", "post_count": 3}]
+    assert len(count_queries) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_paginated_route_applies_plan_to_the_page(blog, count_queries):
+    class TwoPerPage(PageNumberPagination):
+        page_size = 2
+
+    api = BoltAPI()
+
+    @api.get("/posts")
+    @paginate(TwoPerPage)
+    async def list_posts(request) -> list[PostFull]:
+        return BlogPost.objects.order_by("id")
+
+    with TestClient(api) as client:
+        response = client.get("/posts?page=1")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [p["title"] for p in items] == ["Post 0", "Post 1"]
+    assert items[0]["comments"][0]["author"]["name"] == "Alice"
+    # count + page(posts+author) + tags + comments
+    assert len(count_queries) == 4

--- a/python/tests/serializers/test_values_fast_path.py
+++ b/python/tests/serializers/test_values_fast_path.py
@@ -104,11 +104,13 @@ class TestValuesEvaluatorRuntime:
     def test_non_column_field_falls_back_to_instances(self, values_user_table):
         evaluate_sync, _ = _compile_serializer_values_evaluators(NonColumnUserSerializer)
         items = evaluate_sync(ValuesPathUser.objects.order_by("id"))
-        # FieldError fallback: model instances, not dicts
-        assert all(isinstance(item, ValuesPathUser) for item in items)
+        # FieldError fallback: instances are projected through the serializer
+        # right there on the ORM thread, so the evaluator still yields dicts.
+        assert items and all(isinstance(item, dict) for item in items)
+        assert set(items[0]) == set(NonColumnUserSerializer.__struct_fields__)
         # And the verdict is cached: second call goes straight to instances
         items2 = evaluate_sync(ValuesPathUser.objects.order_by("id"))
-        assert all(isinstance(item, ValuesPathUser) for item in items2)
+        assert items2 == items
 
 
 @pytest.mark.django_db(transaction=True)

--- a/python/tests/test_openapi_codegen_gaps.py
+++ b/python/tests/test_openapi_codegen_gaps.py
@@ -1,0 +1,419 @@
+"""
+Failing tests for the schema/codegen gaps reported in #295 (DRF → Bolt migration).
+
+Each section pins the *expected* public contract for one sub-issue so the fix is
+test-driven (RED first):
+
+- #287: parametrized generic Serializers (``Page[UserRead]``) must render as a
+  named component (msgspec naming: ``Page_UserRead_``), not ``{"type": "object"}``.
+- #288: a pagination class can own its envelope via ``response_class`` +
+  ``build_response()``; both the wire body and the schema follow it.
+- #289: ``include_in_schema=False`` on route decorators; ``response_class`` is
+  honored by the schema generator (media type + schema).
+- #290: ``OpenAPIConfig(strict=True)`` fails schema generation for opaque
+  responses and for components that needed the qualified-name fallback.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Generic, TypeVar
+
+import msgspec
+import pytest
+
+from django_bolt import BoltAPI
+from django_bolt.openapi import OpenAPIConfig
+from django_bolt.openapi.schema_generator import OpenAPIStrictError, SchemaGenerator
+from django_bolt.pagination import PageNumberPagination, paginate
+from django_bolt.responses import (
+    HTML,
+    EventSourceResponse,
+    File,
+    PlainText,
+    Redirect,
+    StreamingResponse,
+)
+from django_bolt.serializers import Serializer
+from django_bolt.testing import TestClient
+
+from .test_models import Article
+
+T = TypeVar("T")
+
+
+class UserRead(Serializer):
+    id: int
+    name: str
+
+
+class Page(Serializer, Generic[T]):  # noqa: UP046 — PEP 695 params break Serializer under PEP 563
+    """A page of results."""
+
+    count: int
+    results: list[T]
+
+
+class StructPage(msgspec.Struct, Generic[T]):  # noqa: UP046
+    count: int
+    results: list[T]
+
+
+class ArticleListSchema(msgspec.Struct):
+    id: int
+    title: str
+
+
+def _get_schema(api: BoltAPI) -> dict:
+    api._register_openapi_routes()
+    with TestClient(api) as client:
+        response = client.get("/docs/openapi.json")
+        assert response.status_code == 200
+        return response.json()
+
+
+def _config(**kwargs) -> OpenAPIConfig:
+    return OpenAPIConfig(title="Test API", version="1.0.0", **kwargs)
+
+
+def _ok_response(schema: dict, path: str, method: str = "get", status: str = "200") -> dict:
+    return schema["paths"][path][method]["responses"][status]
+
+
+# ---------------------------------------------------------------------------
+# #287 — parametrized generic Serializers / Structs
+# ---------------------------------------------------------------------------
+
+
+def test_generic_serializer_response_renders_named_component():
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/users")
+    async def list_users() -> Page[UserRead]:
+        return Page(count=1, results=[UserRead(id=1, name="a")])
+
+    schema = _get_schema(api)
+    body = _ok_response(schema, "/users")["content"]["application/json"]["schema"]
+
+    # Not the opaque fallback — a $ref to a component named like msgspec does.
+    assert body == {"$ref": "#/components/schemas/Page_UserRead_"}
+
+    component = schema["components"]["schemas"]["Page_UserRead_"]
+    assert component["type"] == "object"
+    assert component["title"] == "Page[UserRead]"
+    assert component["description"] == "A page of results."
+    assert component["properties"]["count"] == {"type": "integer"}
+    assert component["properties"]["results"] == {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/UserRead"},
+    }
+    assert set(component["required"]) == {"count", "results"}
+    # The item type is registered as its own component too.
+    assert schema["components"]["schemas"]["UserRead"]["properties"]["name"] == {"type": "string"}
+
+
+def test_generic_struct_two_parametrizations_are_distinct_components():
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/users")
+    async def list_users() -> StructPage[UserRead]:
+        return StructPage(count=0, results=[])
+
+    @api.get("/ids")
+    async def list_ids() -> StructPage[int]:
+        return StructPage(count=0, results=[])
+
+    schema = _get_schema(api)
+    components = schema["components"]["schemas"]
+
+    assert _ok_response(schema, "/users")["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/StructPage_UserRead_"
+    }
+    assert _ok_response(schema, "/ids")["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/StructPage_int_"
+    }
+    assert components["StructPage_int_"]["properties"]["results"] == {"type": "array", "items": {"type": "integer"}}
+    assert components["StructPage_UserRead_"]["properties"]["results"]["items"] == {
+        "$ref": "#/components/schemas/UserRead"
+    }
+
+
+def test_generic_serializer_round_trips_on_the_wire():
+    """The runtime already handles generics; pin it so the schema fix cannot regress it."""
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/users")
+    async def list_users() -> Page[UserRead]:
+        return Page(count=1, results=[UserRead(id=1, name="a")])
+
+    with TestClient(api) as client:
+        response = client.get("/users")
+        assert response.status_code == 200
+        assert response.json() == {"count": 1, "results": [{"id": 1, "name": "a"}]}
+
+
+def test_paginated_route_documents_the_envelope_not_a_bare_list():
+    """``@paginate`` returns ``PaginatedResponse[T]`` on the wire, so the schema must say so."""
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/users")
+    @paginate(PageNumberPagination)
+    async def list_users(request) -> list[UserRead]:
+        return [UserRead(id=1, name="a")]
+
+    schema = _get_schema(api)
+    body = _ok_response(schema, "/users")["content"]["application/json"]["schema"]
+    assert body == {"$ref": "#/components/schemas/PaginatedResponse_UserRead_"}
+
+    envelope = schema["components"]["schemas"]["PaginatedResponse_UserRead_"]
+    assert envelope["properties"]["items"] == {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/UserRead"},
+    }
+    assert envelope["properties"]["total"] == {"type": "integer"}
+    assert {"items", "total", "has_next", "has_previous"} <= set(envelope["required"])
+
+
+# ---------------------------------------------------------------------------
+# #288 — custom pagination envelope
+# ---------------------------------------------------------------------------
+
+
+class DRFPage(Serializer, Generic[T]):  # noqa: UP046
+    count: int
+    next: str | None
+    previous: str | None
+    results: list[T]
+
+
+class DRFPagination(PageNumberPagination):
+    page_size = 2
+    response_class = DRFPage
+
+    def build_response(self, items, *, total, request, page, page_size, has_next, has_previous, **_info):
+        base = f"/articles?page_size={page_size}&page="
+        return DRFPage(
+            count=total,
+            next=f"{base}{page + 1}" if has_next else None,
+            previous=f"{base}{page - 1}" if has_previous else None,
+            results=items,
+        )
+
+
+@pytest.fixture
+def five_articles(db):
+    return [
+        Article.objects.create(title=f"Article {i}", content="c", author="a", is_published=True) for i in range(1, 6)
+    ]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_custom_pagination_envelope_on_the_wire(five_articles):
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/articles")
+    @paginate(DRFPagination)
+    async def list_articles(request) -> list[ArticleListSchema]:
+        return Article.objects.order_by("id")
+
+    with TestClient(api) as client:
+        response = client.get("/articles?page=2")
+        assert response.status_code == 200
+        data = response.json()
+
+    assert set(data) == {"count", "next", "previous", "results"}
+    assert data["count"] == 5
+    assert data["next"] == "/articles?page_size=2&page=3"
+    assert data["previous"] == "/articles?page_size=2&page=1"
+    assert [a["title"] for a in data["results"]] == ["Article 3", "Article 4"]
+    # Items are still serialized through the item schema (projection, not full model).
+    assert set(data["results"][0]) == {"id", "title"}
+
+
+def test_custom_pagination_envelope_in_schema():
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/articles")
+    @paginate(DRFPagination)
+    async def list_articles(request) -> list[ArticleListSchema]:
+        return Article.objects.all()
+
+    schema = _get_schema(api)
+    body = _ok_response(schema, "/articles")["content"]["application/json"]["schema"]
+    assert body == {"$ref": "#/components/schemas/DRFPage_ArticleListSchema_"}
+
+    envelope = schema["components"]["schemas"]["DRFPage_ArticleListSchema_"]
+    assert set(envelope["properties"]) == {"count", "next", "previous", "results"}
+    assert envelope["properties"]["results"] == {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/ArticleListSchema"},
+    }
+    # No trace of the default envelope.
+    assert "PaginatedResponse_ArticleListSchema_" not in schema["components"]["schemas"]
+
+
+# ---------------------------------------------------------------------------
+# #289 — include_in_schema + response_class media types
+# ---------------------------------------------------------------------------
+
+
+def test_include_in_schema_false_hides_route_but_still_serves_it():
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/public")
+    async def public() -> UserRead:
+        return UserRead(id=1, name="a")
+
+    @api.get("/internal", include_in_schema=False)
+    async def internal() -> UserRead:
+        return UserRead(id=2, name="b")
+
+    schema = _get_schema(api)
+    assert "/public" in schema["paths"]
+    assert "/internal" not in schema["paths"]
+
+    with TestClient(api) as client:
+        assert client.get("/internal").json() == {"id": 2, "name": "b"}
+
+
+def test_include_in_schema_false_hides_route_in_prefixed_api():
+    api = BoltAPI(prefix="/api/v1", openapi_config=_config())
+
+    @api.get("/internal", include_in_schema=False)
+    async def internal():
+        return {"ok": True}
+
+    schema = _get_schema(api)
+    assert not any(path.endswith("/internal") for path in schema["paths"])
+
+
+@pytest.mark.parametrize(
+    ("response_class", "media_type", "expected_schema"),
+    [
+        (HTML, "text/html", {"type": "string"}),
+        (PlainText, "text/plain", {"type": "string"}),
+        (File, "application/octet-stream", {"type": "string", "format": "binary"}),
+        (StreamingResponse, "application/octet-stream", {"type": "string", "format": "binary"}),
+        (EventSourceResponse, "text/event-stream", {"type": "string"}),
+    ],
+    ids=["html", "plaintext", "file", "streaming", "sse"],
+)
+def test_response_class_sets_media_type_instead_of_json_object(response_class, media_type, expected_schema):
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/thing", response_class=response_class)
+    async def thing():
+        pass
+
+    schema = _get_schema(api)
+    content = _ok_response(schema, "/thing")["content"]
+    assert list(content) == [media_type]
+    assert content[media_type]["schema"] == expected_schema
+
+
+def test_response_class_redirect_documents_3xx_without_content():
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/go", response_class=Redirect)
+    async def go():
+        return Redirect("/elsewhere")
+
+    schema = _get_schema(api)
+    responses = schema["paths"]["/go"]["get"]["responses"]
+    assert "200" not in responses
+    assert "content" not in responses["307"]
+    assert responses["307"]["headers"]["Location"]["schema"] == {"type": "string"}
+
+
+# ---------------------------------------------------------------------------
+# #290 — strict mode
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_fails_on_opaque_json_response():
+    api = BoltAPI(openapi_config=_config(strict=True))
+
+    @api.get("/typed")
+    async def typed() -> UserRead:
+        return UserRead(id=1, name="a")
+
+    @api.get("/untyped")
+    async def untyped():
+        return {"a": 1}
+
+    with pytest.raises(OpenAPIStrictError) as exc_info:
+        SchemaGenerator(api, api._openapi_config).generate()
+
+    message = str(exc_info.value)
+    assert "GET /untyped" in message
+    assert "/typed" not in message
+
+
+def test_strict_mode_reports_every_offender_at_once():
+    api = BoltAPI(openapi_config=_config(strict=True))
+
+    @api.get("/a")
+    async def a():
+        return {}
+
+    @api.post("/b")
+    async def b():
+        return {}
+
+    with pytest.raises(OpenAPIStrictError) as exc_info:
+        SchemaGenerator(api, api._openapi_config).generate()
+
+    message = str(exc_info.value)
+    assert "GET /a" in message
+    assert "POST /b" in message
+
+
+def test_strict_mode_ignores_routes_excluded_from_schema():
+    api = BoltAPI(openapi_config=_config(strict=True))
+
+    @api.get("/untyped", include_in_schema=False)
+    async def untyped():
+        return {"a": 1}
+
+    @api.get("/pixel.gif", response_class=File)
+    async def pixel():
+        pass
+
+    # Neither is an opaque JSON object: one is hidden, one is documented as binary.
+    SchemaGenerator(api, api._openapi_config).generate()
+
+
+def test_strict_mode_fails_on_qualified_component_name_fallback():
+    first = types.new_class("Item", (msgspec.Struct,), {}, lambda ns: ns.update({"__annotations__": {"id": int}}))
+    first.__module__ = "app_one.schemas"
+    second = types.new_class("Item", (msgspec.Struct,), {}, lambda ns: ns.update({"__annotations__": {"name": str}}))
+    second.__module__ = "app_two.schemas"
+
+    api = BoltAPI(openapi_config=_config(strict=True))
+
+    @api.get("/one", response_model=first)
+    async def one():
+        pass
+
+    @api.get("/two", response_model=second)
+    async def two():
+        pass
+
+    with pytest.raises(OpenAPIStrictError) as exc_info:
+        SchemaGenerator(api, api._openapi_config).generate()
+
+    message = str(exc_info.value)
+    assert "app_one.schemas.Item" in message
+    assert "app_two.schemas.Item" in message
+
+
+def test_non_strict_mode_keeps_generating_for_opaque_responses():
+    """Default stays permissive: existing apps with untyped handlers keep working."""
+    api = BoltAPI(openapi_config=_config())
+
+    @api.get("/untyped")
+    async def untyped():
+        return {"a": 1}
+
+    schema = _get_schema(api)
+    assert _ok_response(schema, "/untyped")["content"]["application/json"]["schema"] == {"type": "object"}

--- a/python/tests/test_pagination_serializers.py
+++ b/python/tests/test_pagination_serializers.py
@@ -7,7 +7,6 @@ or return type annotation for efficient batch serialization.
 
 from __future__ import annotations
 
-import asyncio
 import builtins
 
 import msgspec
@@ -289,21 +288,19 @@ def test_paginate_with_nested_serializer_uses_afrom_model(sample_blog_posts):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_paginate_serializes_page_items_concurrently(sample_blog_posts, monkeypatch):
-    """Test paginated async serialization gathers item-level afrom_model() calls."""
+def test_paginate_preloads_relations_instead_of_per_item_async_loading(sample_blog_posts, monkeypatch):
+    """A page of nested-FK items is served from the serializer's loading plan.
+
+    The relation is select_related before the slice is evaluated, so the
+    per-item ``afrom_model()`` fallback (one query per row on the loop) is
+    never needed.
+    """
     api = BoltAPI()
-    original_afrom_model = Serializer.afrom_model.__func__
-    first_started = asyncio.Event()
-    second_started = asyncio.Event()
     seen_ids: list[int] = []
+    original_afrom_model = Serializer.afrom_model.__func__
 
     async def tracked_afrom_model(cls, instance, *, _depth=0, max_depth=10):
         seen_ids.append(instance.pk)
-        if not first_started.is_set():
-            first_started.set()
-            await asyncio.wait_for(second_started.wait(), timeout=0.5)
-        else:
-            second_started.set()
         return await original_afrom_model(cls, instance, _depth=_depth, max_depth=max_depth)
 
     monkeypatch.setattr(
@@ -326,7 +323,8 @@ def test_paginate_serializes_page_items_concurrently(sample_blog_posts, monkeypa
 
         data = response.json()
         assert len(data["items"]) == 2
-        assert len(seen_ids) == 2
+        assert data["items"][0]["author"]["name"].startswith("Author ")
+        assert seen_ids == []
 
 
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -272,16 +272,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.7"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ provides-extras = ["yaml", "nanodjango", "mcp", "bolt-mcp"]
 dev = [
     { name = "bolt-mcp", editable = "python/bolt-mcp" },
     { name = "cryptography", specifier = ">=42" },
-    { name = "django", specifier = "==6.0.7" },
+    { name = "django", specifier = "==6.1" },
     { name = "maturin", specifier = ">=1.9.6" },
     { name = "nanodjango", specifier = ">=0.16" },
     { name = "openapi-spec-validator", specifier = ">=0.8.5" },
@@ -370,15 +370,15 @@ docs = [{ name = "zensical" }]
 
 [[package]]
 name = "django-ninja"
-version = "1.6.2"
+version = "1.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/7c/3307e17b872f545c88314b2737a22f965785dfb5a120d739b0131d0492c3/django_ninja-1.6.2.tar.gz", hash = "sha256:d56ae5aa4791068ef4ac9a66cfdf2fc11f507413ded35abb79c51d0d52ad6412", size = 3685599, upload-time = "2026-03-18T20:06:47.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/9a/558489e0e25173772fbd826306b7d1777e80285b02d69e0e1aaec41e3eec/django_ninja-1.4.5.tar.gz", hash = "sha256:aa1a2ee2b22c5f1c2f4bfbc004386be7074cbfaf133680c2b359a31221965503", size = 3710511, upload-time = "2025-10-19T18:28:02.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/0c/25f72060a39632fbd2d90e9c8b6052a09cd45b0598fc06c0758d313f0052/django_ninja-1.6.2-py3-none-any.whl", hash = "sha256:20095f5900bada22ea00cf1a58af50bdb285b2354c61a9d9b47d0dc89ac462d6", size = 2374994, upload-time = "2026-03-18T20:06:45.676Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e3/168274a8def4b9a2fb2540319a68914e8e4e529cd7f7b5f1ba8939d011bc/django_ninja-1.4.5-py3-none-any.whl", hash = "sha256:d779702ddc6e17b10739049ddb075a6a1e6c6270bdc04e0b0429f6adbf670373", size = 2426449, upload-time = "2025-10-19T18:28:00.518Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #287, closes #288, closes #289, closes #290, closes #292, closes #296. Addresses the priority items of #295.

## Serializers (#292 / #295)
- `Serializer.from_models(qs)`, `afrom_models(qs)`, `loading_plan(Model)`: the serializer derives `select_related` (FK/O2O, dotted `source`), `prefetch_related` (M2M/reverse, nested serializer plan inside the `Prefetch`), and `annotate` (`Config.annotations`) from its own fields. Django 6.1+ adds `fetch_mode(FETCH_PEERS)`. Additive: loads the caller applied are kept and never duplicated.
- `list[Serializer]` routes and `@paginate` pages that return a bare QuerySet get the plan automatically — no N+1, no user code. Async routes iterate with the async ORM; no thread hop.
- Fix: a fieldless `Serializer` subclass dumped `{}`.

## OpenAPI (#287, #288, #289, #290)
- **#287** `Page[UserRead]` renders as component `Page_UserRead_` (msgspec naming), one component per parametrization; `@paginate` routes document `PaginatedResponse_UserRead_` instead of a bare array.
- **#288** `PaginationBase.response_class` + `build_response(items, *, total, request, has_next, has_previous, **info)`: custom envelope on the wire and in the schema.
- **#289** `include_in_schema=False` on all route decorators (was documented, not implemented). `response_class` sets media type/schema: `HTML`→`text/html`, `PlainText`→`text/plain`, `File`/`FileResponse`/`StreamingResponse`→`application/octet-stream` binary, `EventSourceResponse`→`text/event-stream`, `Redirect`→3xx + `Location`, no body.
- **#290** `OpenAPIConfig(strict=True)` → `OpenAPIStrictError` listing every untyped JSON response and every component that needed the `module.qualname` fallback.
- `PaginatedResponse` now uses `Generic[T]`: its PEP 695 type param could not be resolved under PEP 563, so `items` was documented as `Any`.

## bolt-mcp (#296)
- The OAuth AS routes and the protected-resource metadata route register with `auth=[], guards=[]`; global `BOLT_DEFAULT_PERMISSION_CLASSES` / `BOLT_AUTHENTICATION_CLASSES` no longer 401 discovery. `mount_mcp(auth=..., guards=...)` still overrides globals for `/mcp` itself.

## Tests
- `python/tests/serializers/test_loading_plan.py` (18), `python/tests/test_openapi_codegen_gaps.py` (19, written RED first), `test_oauth_as.py::test_oauth_routes_are_public_under_global_default_guards`, regression in `test_base.py`.
- Full suite 2602 passed; bolt-mcp 165 passed; ruff clean.

## Docs
`topics/serializers.md` (from_models), `topics/pagination.md` (custom envelope, N+1), `topics/openapi.md` (strict mode, non-JSON responses, generic naming).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

Yes. The PR changes QuerySet and paginated response handling.

Per request, the code:

- Retrieves or builds a cached serializer `LoadingPlan`.
- Applies required `select_related()`, `prefetch_related()`, annotations, and peer fetching.
- Uses `from_models()` or `afrom_models()` for bulk serialization.
- Preloads relations before pagination serialization.
- Builds the configured pagination response envelope.

The loading plan is cached by serializer and model class. Plan construction does not repeat for each request.

QuerySet preparation, evaluation, and bulk serialization still run per request. This work is required to implement automatic loading plans and prevent per-object relation queries and N+1 database access.

The main added cost is applying the loading plan before evaluation. The plan preserves and deduplicates caller-provided loads. This cost replaces potentially more expensive per-object queries.

Custom pagination adds the required response-envelope construction. OpenAPI, documentation, strict validation, and MCP route changes do not affect normal serializer request processing.

The PR does not indicate unnecessary work in the hot path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->