### PR TITLE
fix(rate-limit)!: trust X-Forwarded-For only from a declared proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- **`@rate_limit(key="ip")` trusted `X-Forwarded-For`** - The key came from the leftmost entry of `X-Forwarded-For`, which the client sends. Behind a proxy that appends the header, and with Bolt exposed directly, a client changed one header and got a new bucket for every request. Bolt now keys on the peer address and ignores forwarding headers. Set `BOLT_TRUSTED_PROXIES` to the addresses or CIDR blocks of your proxies to read `X-Forwarded-For` again. Bolt then reads it from the right and takes the first entry that is not a listed proxy. **Add the setting if you run behind a proxy**, or every caller behind it shares one bucket. (#302)
+- **`@rate_limit(key="ip")` trusted `X-Forwarded-For`** - The key came from the leftmost entry of `X-Forwarded-For`, which the client sends. Behind a proxy that appends the header, and with Bolt exposed directly, a client changed one header and got a new bucket for every request. Bolt now uses one canonical client address for rate limiting, `request.META["REMOTE_ADDR"]`, and request logging: the peer address by default, or the first untrusted `X-Forwarded-For` hop when the peer matches `BOLT_TRUSTED_PROXIES`. Malformed chains fall back to the peer. **Add the setting if you run behind a proxy**, or every caller behind it shares one bucket. (#302)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **`@rate_limit(key="ip")` trusted `X-Forwarded-For`** - The key came from the leftmost entry of `X-Forwarded-For`, which the client sends. Behind a proxy that appends the header, and with Bolt exposed directly, a client changed one header and got a new bucket for every request. Bolt now keys on the peer address and ignores forwarding headers. Set `BOLT_TRUSTED_PROXIES` to the addresses or CIDR blocks of your proxies to read `X-Forwarded-For` again. Bolt then reads it from the right and takes the first entry that is not a listed proxy. **Add the setting if you run behind a proxy**, or every caller behind it shares one bucket. (#302)
+
 ### Fixed
 
 - **bolt-mcp 0.2.2: `resultType` on Python-built results** - `tools/call`, `resources/read` and `prompts/get` results now carry `resultType: "complete"` for 2026-07-28 clients. Claude Code and claude.ai connectors rejected every tool call without it. Legacy peers keep the old wire shape.

--- a/crates/bolt-core/src/metadata.rs
+++ b/crates/bolt-core/src/metadata.rs
@@ -866,7 +866,7 @@ fn parse_rate_limit_config(
     // check can look them up directly (headers are stored lowercase).
     if let Some(key_py) = dict.get("key") {
         if let Ok(key_type) = key_py.extract::<String>(py) {
-            config.key = if key_type == "ip" {
+            config.key = if key_type.eq_ignore_ascii_case("ip") {
                 RateLimitKey::Ip
             } else {
                 RateLimitKey::Header(key_type.to_lowercase())

--- a/crates/bolt-core/src/metadata.rs
+++ b/crates/bolt-core/src/metadata.rs
@@ -16,6 +16,7 @@ use crate::middleware::auth::{
     build_jwks_key_source, build_jwt_decoding_key, parse_jwt_algorithm, AuthBackend, JwtKeySource,
     RefreshingJwks,
 };
+use crate::middleware::client_ip::IpCidr;
 use crate::permissions::{ClaimKey, Guard, GuardDenial, GuardSet, Quantifier};
 
 /// Request value source for Rust-side argument prebinding.
@@ -215,6 +216,11 @@ pub struct RateLimitConfig {
     pub rps: u32,
     pub burst: u32,
     pub key_type: String,
+    /// Proxies whose forwarding headers a `key="ip"` limit may believe.
+    ///
+    /// Comes from `settings.BOLT_TRUSTED_PROXIES` and is empty by default. An
+    /// empty list makes the limit key on the peer address only.
+    pub trusted_proxies: Vec<IpCidr>,
 }
 
 impl Default for RateLimitConfig {
@@ -223,6 +229,7 @@ impl Default for RateLimitConfig {
             rps: 100,
             burst: 200,
             key_type: "ip".to_string(),
+            trusted_proxies: Vec::new(),
         }
     }
 }
@@ -549,6 +556,15 @@ impl RouteMetadata {
             }
         }
 
+        // Attach the trusted proxy list. Proxies are a property of the
+        // deployment, not of one route, so Python resolves
+        // `settings.BOLT_TRUSTED_PROXIES` once at registration and sends it
+        // beside the middleware list. A bad entry aborts startup: keying a
+        // limit on the wrong address is a silent security downgrade.
+        if let Some(config) = rate_limit_config.as_mut() {
+            config.trusted_proxies = parse_trusted_proxies(py_meta)?;
+        }
+
         // Parse auth backends. Failures propagate: metadata that fails to
         // extract must abort startup, not leave the route unauthenticated.
         if let Some(auth_list) = py_meta.get_item("auth_backends")? {
@@ -829,6 +845,32 @@ fn parse_cors_config(dict: &HashMap<String, Py<PyAny>>, py: Python) -> Option<Co
 }
 
 /// Parse rate limiting configuration from middleware dict
+/// Read `trusted_proxies` from route metadata.
+///
+/// Python validates the setting first, so anything invalid here is a bug.
+fn parse_trusted_proxies(py_meta: &Bound<'_, PyDict>) -> PyResult<Vec<IpCidr>> {
+    let Some(value) = py_meta.get_item("trusted_proxies")? else {
+        return Ok(Vec::new());
+    };
+    if value.is_none() {
+        return Ok(Vec::new());
+    }
+
+    let entries: Vec<String> = value.extract().map_err(|e| {
+        PyValueError::new_err(format!(
+            "Invalid 'trusted_proxies' route metadata, expected a list of strings: {e}"
+        ))
+    })?;
+
+    let mut blocks = Vec::with_capacity(entries.len());
+    for entry in entries {
+        blocks.push(IpCidr::parse(&entry).map_err(|e| {
+            PyValueError::new_err(format!("Invalid BOLT_TRUSTED_PROXIES entry: {e}"))
+        })?);
+    }
+    Ok(blocks)
+}
+
 fn parse_rate_limit_config(
     dict: &HashMap<String, Py<PyAny>>,
     py: Python,

--- a/crates/bolt-core/src/metadata.rs
+++ b/crates/bolt-core/src/metadata.rs
@@ -16,7 +16,6 @@ use crate::middleware::auth::{
     build_jwks_key_source, build_jwt_decoding_key, parse_jwt_algorithm, AuthBackend, JwtKeySource,
     RefreshingJwks,
 };
-use crate::middleware::client_ip::IpCidr;
 use crate::permissions::{ClaimKey, Guard, GuardDenial, GuardSet, Quantifier};
 
 /// Request value source for Rust-side argument prebinding.
@@ -215,12 +214,16 @@ impl CorsConfig {
 pub struct RateLimitConfig {
     pub rps: u32,
     pub burst: u32,
-    pub key_type: String,
-    /// Proxies whose forwarding headers a `key="ip"` limit may believe.
-    ///
-    /// Comes from `settings.BOLT_TRUSTED_PROXIES` and is empty by default. An
-    /// empty list makes the limit key on the peer address only.
-    pub trusted_proxies: Vec<IpCidr>,
+    pub key: RateLimitKey,
+}
+
+/// What a rate limit buckets on. Decided once at registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitKey {
+    /// The resolved client address. See `middleware::client_ip`.
+    Ip,
+    /// One request header, stored lowercase for direct lookup.
+    Header(String),
 }
 
 impl Default for RateLimitConfig {
@@ -228,8 +231,7 @@ impl Default for RateLimitConfig {
         RateLimitConfig {
             rps: 100,
             burst: 200,
-            key_type: "ip".to_string(),
-            trusted_proxies: Vec::new(),
+            key: RateLimitKey::Ip,
         }
     }
 }
@@ -556,15 +558,6 @@ impl RouteMetadata {
             }
         }
 
-        // Attach the trusted proxy list. Proxies are a property of the
-        // deployment, not of one route, so Python resolves
-        // `settings.BOLT_TRUSTED_PROXIES` once at registration and sends it
-        // beside the middleware list. A bad entry aborts startup: keying a
-        // limit on the wrong address is a silent security downgrade.
-        if let Some(config) = rate_limit_config.as_mut() {
-            config.trusted_proxies = parse_trusted_proxies(py_meta)?;
-        }
-
         // Parse auth backends. Failures propagate: metadata that fails to
         // extract must abort startup, not leave the route unauthenticated.
         if let Some(auth_list) = py_meta.get_item("auth_backends")? {
@@ -845,32 +838,6 @@ fn parse_cors_config(dict: &HashMap<String, Py<PyAny>>, py: Python) -> Option<Co
 }
 
 /// Parse rate limiting configuration from middleware dict
-/// Read `trusted_proxies` from route metadata.
-///
-/// Python validates the setting first, so anything invalid here is a bug.
-fn parse_trusted_proxies(py_meta: &Bound<'_, PyDict>) -> PyResult<Vec<IpCidr>> {
-    let Some(value) = py_meta.get_item("trusted_proxies")? else {
-        return Ok(Vec::new());
-    };
-    if value.is_none() {
-        return Ok(Vec::new());
-    }
-
-    let entries: Vec<String> = value.extract().map_err(|e| {
-        PyValueError::new_err(format!(
-            "Invalid 'trusted_proxies' route metadata, expected a list of strings: {e}"
-        ))
-    })?;
-
-    let mut blocks = Vec::with_capacity(entries.len());
-    for entry in entries {
-        blocks.push(IpCidr::parse(&entry).map_err(|e| {
-            PyValueError::new_err(format!("Invalid BOLT_TRUSTED_PROXIES entry: {e}"))
-        })?);
-    }
-    Ok(blocks)
-}
-
 fn parse_rate_limit_config(
     dict: &HashMap<String, Py<PyAny>>,
     py: Python,
@@ -899,10 +866,10 @@ fn parse_rate_limit_config(
     // check can look them up directly (headers are stored lowercase).
     if let Some(key_py) = dict.get("key") {
         if let Ok(key_type) = key_py.extract::<String>(py) {
-            config.key_type = if key_type == "ip" {
-                key_type
+            config.key = if key_type == "ip" {
+                RateLimitKey::Ip
             } else {
-                key_type.to_lowercase()
+                RateLimitKey::Header(key_type.to_lowercase())
             };
         }
     }

--- a/crates/bolt-core/src/middleware/client_ip.rs
+++ b/crates/bolt-core/src/middleware/client_ip.rs
@@ -9,8 +9,10 @@
 //! list is empty by default. With an empty list Bolt ignores every forwarding
 //! header and keys on the peer address.
 
-use ahash::AHashMap;
-use std::net::IpAddr;
+use actix_web::http::header::HeaderMap;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use std::net::{IpAddr, SocketAddr};
 
 /// One entry of the trusted proxy list.
 ///
@@ -34,11 +36,9 @@ impl IpCidr {
             None => (entry, None),
         };
 
-        let network = normalize(
-            address
-                .parse::<IpAddr>()
-                .map_err(|_| format!("{entry:?} is not an IP address or CIDR block"))?,
-        );
+        let network = address
+            .parse::<IpAddr>()
+            .map_err(|_| format!("{entry:?} is not an IP address or CIDR block"))?;
         let max_prefix_len = if network.is_ipv4() { 32 } else { 128 };
 
         let prefix_len = match prefix {
@@ -61,18 +61,62 @@ impl IpCidr {
 
     /// Report whether `candidate` is inside this block.
     ///
-    /// An IPv4 block never matches an IPv6 address, and the reverse. Both sides
-    /// are normalized first, so `::ffff:10.0.0.1` matches `10.0.0.0/8`.
+    /// An IPv4 block matches an IPv4-mapped IPv6 peer. An explicitly configured
+    /// IPv4-mapped IPv6 block remains IPv6, preserving its prefix length.
     pub fn contains(&self, candidate: &IpAddr) -> bool {
-        match (self.network, normalize(*candidate)) {
-            (IpAddr::V4(network), IpAddr::V4(candidate)) => {
-                prefix_eq(&network.octets(), &candidate.octets(), self.prefix_len)
-            }
-            (IpAddr::V6(network), IpAddr::V6(candidate)) => {
-                prefix_eq(&network.octets(), &candidate.octets(), self.prefix_len)
-            }
-            _ => false,
+        match self.network {
+            IpAddr::V4(network) => match normalize(*candidate) {
+                IpAddr::V4(candidate) => {
+                    prefix_eq(&network.octets(), &candidate.octets(), self.prefix_len)
+                }
+                IpAddr::V6(_) => false,
+            },
+            IpAddr::V6(network) => match candidate {
+                IpAddr::V6(candidate) => {
+                    prefix_eq(&network.octets(), &candidate.octets(), self.prefix_len)
+                }
+                IpAddr::V4(_) => false,
+            },
         }
+    }
+}
+
+/// Deployment-wide proxy trust policy, parsed once for one server or test app.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TrustedProxies {
+    blocks: Vec<IpCidr>,
+}
+
+impl TrustedProxies {
+    pub fn parse(entries: &[String]) -> Result<Self, String> {
+        let blocks = entries
+            .iter()
+            .map(|entry| IpCidr::parse(entry))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { blocks })
+    }
+
+    /// Preserve Python's `ImproperlyConfigured` validation while building the
+    /// Rust hot-path representation only once at application startup.
+    pub fn from_django_settings(py: Python<'_>) -> PyResult<Self> {
+        let entries: Vec<String> = py
+            .import("django_bolt.middleware.compiler")?
+            .getattr("get_trusted_proxies")?
+            .call0()?
+            .extract()?;
+        Self::parse(&entries).map_err(|error| {
+            PyValueError::new_err(format!("Invalid BOLT_TRUSTED_PROXIES entry: {error}"))
+        })
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    #[inline]
+    fn contains(&self, address: &IpAddr) -> bool {
+        self.blocks.iter().any(|block| block.contains(address))
     }
 }
 
@@ -111,11 +155,20 @@ fn parse_ip(value: &str) -> Option<IpAddr> {
     value.trim().parse::<IpAddr>().ok().map(normalize)
 }
 
-fn is_trusted(address: &IpAddr, trusted_proxies: &[IpCidr]) -> bool {
-    trusted_proxies.iter().any(|block| block.contains(address))
+/// Parse a forwarding hop. Plain IPs are standard; `SocketAddr` additionally
+/// accepts proxy output such as `192.0.2.1:1234` and `[2001:db8::1]:443`.
+fn parse_forwarded_ip(value: &str) -> Option<IpAddr> {
+    let value = value.trim();
+    parse_ip(value).or_else(|| {
+        value
+            .parse::<SocketAddr>()
+            .ok()
+            .map(|address| normalize(address.ip()))
+    })
 }
 
-/// Resolve the address that a `key="ip"` rate limit applies to.
+/// Resolve the canonical client address used by rate limiting, Django request
+/// metadata, and request logging.
 ///
 /// The rules are:
 ///
@@ -126,80 +179,141 @@ fn is_trusted(address: &IpAddr, trusted_proxies: &[IpCidr]) -> bool {
 /// 3. With a trusted peer, read `X-Forwarded-For` from the right. Return the
 ///    first entry that is not a trusted proxy. That entry is the client.
 /// 4. When every `X-Forwarded-For` entry is trusted, return the leftmost entry.
-/// 5. Fall back to `X-Real-IP`, then `Remote-Addr`, then the peer address.
+/// 5. Fall back to a valid `X-Real-IP`, then the peer address.
+/// 6. A malformed forwarding chain falls back to the peer; it never exposes an
+///    attacker-controlled entry farther left.
 ///
 /// Returns `None` only when there is no peer address and no usable header. The
 /// caller then keys on a constant.
-pub fn resolve(
-    headers: &AHashMap<String, String>,
-    peer_addr: Option<&str>,
-    trusted_proxies: &[IpCidr],
-) -> Option<String> {
-    let peer = peer_addr.and_then(parse_ip);
-    let peer_key = || {
-        peer.map(|ip| ip.to_string())
-            .or_else(|| peer_addr.map(str::to_string))
-    };
+///
+/// `forwarded_for` yields each `X-Forwarded-For` header value in wire order.
+/// A `None` item is a value that is not valid text. `resolve` reads the values
+/// lazily and from the right, so a request that reaches rule 1 or 2 never
+/// touches them.
+pub fn resolve<'a>(
+    forwarded_for: impl DoubleEndedIterator<Item = Option<&'a str>>,
+    real_ip: Option<Option<&'a str>>,
+    peer_addr: Option<IpAddr>,
+    trusted_proxies: &TrustedProxies,
+) -> Option<IpAddr> {
+    let peer = peer_addr.map(normalize);
 
     if trusted_proxies.is_empty() {
-        return peer_key();
+        return peer;
     }
     match peer {
-        Some(address) if is_trusted(&address, trusted_proxies) => {}
-        _ => return peer_key(),
+        Some(address) if trusted_proxies.contains(&address) => {}
+        _ => return peer,
     }
 
-    if let Some(forwarded) = headers.get("x-forwarded-for") {
-        if let Some(client) = client_from_forwarded_for(forwarded, trusted_proxies) {
-            return Some(client);
-        }
+    match client_from_forwarded_for(forwarded_for, trusted_proxies) {
+        Ok(Some(client)) => return Some(client),
+        Ok(None) => {}
+        // A malformed chain proves nothing. Fall back to the socket peer
+        // instead of searching farther left through client-controlled data.
+        Err(()) => return peer,
     }
-    for header in ["x-real-ip", "remote-addr"] {
-        if let Some(address) = headers.get(header).and_then(|value| parse_ip(value)) {
-            return Some(address.to_string());
-        }
+    if let Some(value) = real_ip {
+        return value.and_then(parse_forwarded_ip).or(peer);
     }
 
-    peer_key()
+    peer
 }
 
-/// Find the client inside one `X-Forwarded-For` value.
-///
-/// The rightmost entry that is not a trusted proxy is the client. Entries that
-/// do not parse are skipped: a bucket key must be an address, and a trusted
-/// proxy always appends the real peer to the right of any junk.
-fn client_from_forwarded_for(value: &str, trusted_proxies: &[IpCidr]) -> Option<String> {
-    let mut leftmost: Option<IpAddr> = None;
-    let mut rightmost_untrusted: Option<IpAddr> = None;
+/// Resolve from an Actix header map. Duplicate `X-Forwarded-For` headers are
+/// read in order without a merge step.
+#[inline]
+pub fn resolve_from_headers(
+    headers: &HeaderMap,
+    peer_addr: Option<IpAddr>,
+    trusted_proxies: &TrustedProxies,
+) -> Option<IpAddr> {
+    resolve(
+        headers
+            .get_all("x-forwarded-for")
+            .map(|value| value.to_str().ok()),
+        headers.get("x-real-ip").map(|value| value.to_str().ok()),
+        peer_addr,
+        trusted_proxies,
+    )
+}
 
-    for entry in value.split(',') {
-        let Some(address) = parse_ip(entry) else {
-            continue;
+/// Find the client across the `X-Forwarded-For` values.
+///
+/// The rightmost entry that is not a trusted proxy is the client. A malformed
+/// hop invalidates the chain; skipping it could expose a spoofed entry farther
+/// left when a proxy emits an unsupported representation of the real client.
+fn client_from_forwarded_for<'a>(
+    values: impl DoubleEndedIterator<Item = Option<&'a str>>,
+    trusted_proxies: &TrustedProxies,
+) -> Result<Option<IpAddr>, ()> {
+    let mut leftmost: Option<IpAddr> = None;
+
+    for value in values.rev() {
+        let Some(value) = value else {
+            return Err(());
         };
-        if leftmost.is_none() {
+        for entry in value.rsplit(',') {
+            let Some(address) = parse_forwarded_ip(entry) else {
+                return Err(());
+            };
             leftmost = Some(address);
-        }
-        if !is_trusted(&address, trusted_proxies) {
-            rightmost_untrusted = Some(address);
+            if !trusted_proxies.contains(&address) {
+                return Ok(Some(address));
+            }
         }
     }
 
-    rightmost_untrusted.or(leftmost).map(|ip| ip.to_string())
+    Ok(leftmost)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::http::header::{HeaderName, HeaderValue};
 
-    fn cidrs(entries: &[&str]) -> Vec<IpCidr> {
-        entries.iter().map(|e| IpCidr::parse(e).unwrap()).collect()
+    // Keep expectations readable while the production API stays allocation-free.
+    fn resolve(
+        headers: &HeaderMap,
+        peer_addr: Option<&str>,
+        trusted_proxies: &TrustedProxies,
+    ) -> Option<String> {
+        resolve_from_headers(headers, peer_addr.and_then(parse_ip), trusted_proxies)
+            .map(|address| address.to_string())
     }
 
-    fn headers(pairs: &[(&str, &str)]) -> AHashMap<String, String> {
-        pairs
-            .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-            .collect()
+    fn proxies(entries: &[&str]) -> TrustedProxies {
+        TrustedProxies::parse(
+            &entries
+                .iter()
+                .map(|entry| entry.to_string())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.append(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn reads_duplicate_forwarded_for_headers_in_order() {
+        let resolved = resolve(
+            &headers(&[
+                ("x-forwarded-for", "1.1.1.1, 203.0.113.9"),
+                ("x-forwarded-for", "10.0.0.1"),
+            ]),
+            Some("10.0.0.1"),
+            &proxies(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
 
     #[test]
@@ -236,6 +350,13 @@ mod tests {
     }
 
     #[test]
+    fn accepts_an_explicit_ipv4_mapped_ipv6_proxy() {
+        let block = IpCidr::parse("::ffff:10.0.0.0/104").unwrap();
+        assert!(block.contains(&"::ffff:10.1.2.3".parse().unwrap()));
+        assert!(!block.contains(&"::ffff:11.1.2.3".parse().unwrap()));
+    }
+
+    #[test]
     fn does_not_match_across_families() {
         let block = IpCidr::parse("10.0.0.0/8").unwrap();
         assert!(!block.contains(&"2001:db8::1".parse().unwrap()));
@@ -246,7 +367,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "1.2.3.4")]),
             Some("203.0.113.9"),
-            &[],
+            &TrustedProxies::default(),
         );
         assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
@@ -256,7 +377,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "1.2.3.4")]),
             Some("203.0.113.9"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
@@ -266,7 +387,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "203.0.113.9")]),
             Some("10.0.0.1"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
@@ -276,7 +397,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "203.0.113.9, 10.0.0.7, 10.0.0.1")]),
             Some("10.0.0.1"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
@@ -288,7 +409,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "1.1.1.1, 203.0.113.9, 10.0.0.1")]),
             Some("10.0.0.1"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
@@ -298,7 +419,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "10.0.0.55, 10.0.0.1")]),
             Some("10.0.0.1"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("10.0.0.55"));
     }
@@ -308,7 +429,7 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-real-ip", "203.0.113.9")]),
             Some("10.0.0.1"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
     }
@@ -318,20 +439,61 @@ mod tests {
         let resolved = resolve(
             &headers(&[("x-forwarded-for", "not-an-ip")]),
             Some("10.0.0.1"),
-            &cidrs(&["10.0.0.0/8"]),
+            &proxies(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn malformed_hop_does_not_expose_a_spoofed_prefix() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "1.1.1.1, not-an-ip, 10.0.0.1")]),
+            Some("10.0.0.1"),
+            &proxies(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn accepts_ipv4_and_bracketed_ipv6_hops_with_ports() {
+        let trusted = proxies(&["10.0.0.0/8"]);
+        let ipv4 = resolve(
+            &headers(&[("x-forwarded-for", "203.0.113.9:54321")]),
+            Some("10.0.0.1"),
+            &trusted,
+        );
+        let ipv6 = resolve(
+            &headers(&[("x-forwarded-for", "[2001:db8::9]:54321")]),
+            Some("10.0.0.1"),
+            &trusted,
+        );
+        assert_eq!(ipv4.as_deref(), Some("203.0.113.9"));
+        assert_eq!(ipv6.as_deref(), Some("2001:db8::9"));
+    }
+
+    #[test]
+    fn rejects_a_malformed_x_real_ip() {
+        let resolved = resolve(
+            &headers(&[("x-real-ip", "attacker-chosen-bucket")]),
+            Some("10.0.0.1"),
+            &proxies(&["10.0.0.0/8"]),
         );
         assert_eq!(resolved.as_deref(), Some("10.0.0.1"));
     }
 
     #[test]
     fn normalizes_an_ipv4_mapped_peer_to_one_bucket() {
-        let plain = resolve(&headers(&[]), Some("10.0.0.1"), &[]);
-        let mapped = resolve(&headers(&[]), Some("::ffff:10.0.0.1"), &[]);
+        let proxies = TrustedProxies::default();
+        let plain = resolve(&headers(&[]), Some("10.0.0.1"), &proxies);
+        let mapped = resolve(&headers(&[]), Some("::ffff:10.0.0.1"), &proxies);
         assert_eq!(plain, mapped);
     }
 
     #[test]
     fn returns_none_without_a_peer_or_usable_header() {
-        assert_eq!(resolve(&headers(&[]), None, &[]), None);
+        assert_eq!(
+            resolve(&headers(&[]), None, &TrustedProxies::default()),
+            None
+        );
     }
 }

--- a/crates/bolt-core/src/middleware/client_ip.rs
+++ b/crates/bolt-core/src/middleware/client_ip.rs
@@ -1,0 +1,337 @@
+//! Client address resolution for rate limiting.
+//!
+//! A client sends `X-Forwarded-For` itself. Each proxy appends to it. The
+//! leftmost entry is therefore the value the client chose, not a fact about the
+//! connection. Bolt trusts a forwarding header only when a declared proxy sent
+//! it.
+//!
+//! `settings.BOLT_TRUSTED_PROXIES` declares those proxies as a CIDR list. The
+//! list is empty by default. With an empty list Bolt ignores every forwarding
+//! header and keys on the peer address.
+
+use ahash::AHashMap;
+use std::net::IpAddr;
+
+/// One entry of the trusted proxy list.
+///
+/// A bare address such as `127.0.0.1` gets the full prefix length, so it
+/// matches only itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IpCidr {
+    network: IpAddr,
+    prefix_len: u8,
+}
+
+impl IpCidr {
+    /// Parse one entry, for example `10.0.0.0/8`, `127.0.0.1` or `::1`.
+    ///
+    /// Returns an error message that names the rejected entry. The caller turns
+    /// it into a startup failure.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        let entry = value.trim();
+        let (address, prefix) = match entry.split_once('/') {
+            Some((address, prefix)) => (address, Some(prefix)),
+            None => (entry, None),
+        };
+
+        let network = normalize(
+            address
+                .parse::<IpAddr>()
+                .map_err(|_| format!("{entry:?} is not an IP address or CIDR block"))?,
+        );
+        let max_prefix_len = if network.is_ipv4() { 32 } else { 128 };
+
+        let prefix_len = match prefix {
+            Some(prefix) => prefix
+                .parse::<u8>()
+                .map_err(|_| format!("{entry:?} has a prefix length that is not a number"))?,
+            None => max_prefix_len,
+        };
+        if prefix_len > max_prefix_len {
+            return Err(format!(
+                "{entry:?} has prefix length {prefix_len}, above the maximum of {max_prefix_len}"
+            ));
+        }
+
+        Ok(IpCidr {
+            network,
+            prefix_len,
+        })
+    }
+
+    /// Report whether `candidate` is inside this block.
+    ///
+    /// An IPv4 block never matches an IPv6 address, and the reverse. Both sides
+    /// are normalized first, so `::ffff:10.0.0.1` matches `10.0.0.0/8`.
+    pub fn contains(&self, candidate: &IpAddr) -> bool {
+        match (self.network, normalize(*candidate)) {
+            (IpAddr::V4(network), IpAddr::V4(candidate)) => {
+                prefix_eq(&network.octets(), &candidate.octets(), self.prefix_len)
+            }
+            (IpAddr::V6(network), IpAddr::V6(candidate)) => {
+                prefix_eq(&network.octets(), &candidate.octets(), self.prefix_len)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Compare the first `prefix_len` bits of two addresses.
+fn prefix_eq(network: &[u8], candidate: &[u8], prefix_len: u8) -> bool {
+    let whole_bytes = (prefix_len / 8) as usize;
+    if network[..whole_bytes] != candidate[..whole_bytes] {
+        return false;
+    }
+
+    let leftover_bits = prefix_len % 8;
+    if leftover_bits == 0 {
+        return true;
+    }
+
+    let mask = 0xffu8 << (8 - leftover_bits);
+    network[whole_bytes] & mask == candidate[whole_bytes] & mask
+}
+
+/// Map an IPv4-mapped IPv6 address back to IPv4.
+///
+/// A dual-stack listener reports an IPv4 peer as `::ffff:a.b.c.d`. Without this
+/// step the same client gets two different rate limit buckets.
+fn normalize(address: IpAddr) -> IpAddr {
+    match address {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        v4 => v4,
+    }
+}
+
+/// Parse one address and normalize it. Returns `None` for anything else.
+fn parse_ip(value: &str) -> Option<IpAddr> {
+    value.trim().parse::<IpAddr>().ok().map(normalize)
+}
+
+fn is_trusted(address: &IpAddr, trusted_proxies: &[IpCidr]) -> bool {
+    trusted_proxies.iter().any(|block| block.contains(address))
+}
+
+/// Resolve the address that a `key="ip"` rate limit applies to.
+///
+/// The rules are:
+///
+/// 1. With no trusted proxy declared, use the peer address. Forwarding headers
+///    are client input, so ignore them.
+/// 2. With trusted proxies declared but a peer outside the list, use the peer
+///    address. That peer is not a declared proxy, so its headers prove nothing.
+/// 3. With a trusted peer, read `X-Forwarded-For` from the right. Return the
+///    first entry that is not a trusted proxy. That entry is the client.
+/// 4. When every `X-Forwarded-For` entry is trusted, return the leftmost entry.
+/// 5. Fall back to `X-Real-IP`, then `Remote-Addr`, then the peer address.
+///
+/// Returns `None` only when there is no peer address and no usable header. The
+/// caller then keys on a constant.
+pub fn resolve(
+    headers: &AHashMap<String, String>,
+    peer_addr: Option<&str>,
+    trusted_proxies: &[IpCidr],
+) -> Option<String> {
+    let peer = peer_addr.and_then(parse_ip);
+    let peer_key = || {
+        peer.map(|ip| ip.to_string())
+            .or_else(|| peer_addr.map(str::to_string))
+    };
+
+    if trusted_proxies.is_empty() {
+        return peer_key();
+    }
+    match peer {
+        Some(address) if is_trusted(&address, trusted_proxies) => {}
+        _ => return peer_key(),
+    }
+
+    if let Some(forwarded) = headers.get("x-forwarded-for") {
+        if let Some(client) = client_from_forwarded_for(forwarded, trusted_proxies) {
+            return Some(client);
+        }
+    }
+    for header in ["x-real-ip", "remote-addr"] {
+        if let Some(address) = headers.get(header).and_then(|value| parse_ip(value)) {
+            return Some(address.to_string());
+        }
+    }
+
+    peer_key()
+}
+
+/// Find the client inside one `X-Forwarded-For` value.
+///
+/// The rightmost entry that is not a trusted proxy is the client. Entries that
+/// do not parse are skipped: a bucket key must be an address, and a trusted
+/// proxy always appends the real peer to the right of any junk.
+fn client_from_forwarded_for(value: &str, trusted_proxies: &[IpCidr]) -> Option<String> {
+    let mut leftmost: Option<IpAddr> = None;
+    let mut rightmost_untrusted: Option<IpAddr> = None;
+
+    for entry in value.split(',') {
+        let Some(address) = parse_ip(entry) else {
+            continue;
+        };
+        if leftmost.is_none() {
+            leftmost = Some(address);
+        }
+        if !is_trusted(&address, trusted_proxies) {
+            rightmost_untrusted = Some(address);
+        }
+    }
+
+    rightmost_untrusted.or(leftmost).map(|ip| ip.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cidrs(entries: &[&str]) -> Vec<IpCidr> {
+        entries.iter().map(|e| IpCidr::parse(e).unwrap()).collect()
+    }
+
+    fn headers(pairs: &[(&str, &str)]) -> AHashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_blocks_and_bare_addresses() {
+        assert!(IpCidr::parse("10.0.0.0/8").is_ok());
+        assert!(IpCidr::parse(" 127.0.0.1 ").is_ok());
+        assert!(IpCidr::parse("::1").is_ok());
+        assert!(IpCidr::parse("2001:db8::/32").is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_entries() {
+        assert!(IpCidr::parse("not-an-ip").is_err());
+        assert!(IpCidr::parse("10.0.0.0/nine").is_err());
+        assert!(IpCidr::parse("10.0.0.0/33").is_err());
+        assert!(IpCidr::parse("::1/129").is_err());
+    }
+
+    #[test]
+    fn matches_only_inside_the_block() {
+        let block = IpCidr::parse("10.0.0.0/8").unwrap();
+        assert!(block.contains(&"10.1.2.3".parse().unwrap()));
+        assert!(!block.contains(&"11.0.0.1".parse().unwrap()));
+
+        let narrow = IpCidr::parse("192.168.1.128/25").unwrap();
+        assert!(narrow.contains(&"192.168.1.200".parse().unwrap()));
+        assert!(!narrow.contains(&"192.168.1.127".parse().unwrap()));
+    }
+
+    #[test]
+    fn matches_ipv4_mapped_peers() {
+        let block = IpCidr::parse("10.0.0.0/8").unwrap();
+        assert!(block.contains(&"::ffff:10.1.2.3".parse().unwrap()));
+    }
+
+    #[test]
+    fn does_not_match_across_families() {
+        let block = IpCidr::parse("10.0.0.0/8").unwrap();
+        assert!(!block.contains(&"2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ignores_forwarding_headers_with_no_trusted_proxy() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "1.2.3.4")]),
+            Some("203.0.113.9"),
+            &[],
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn ignores_forwarding_headers_from_an_untrusted_peer() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "1.2.3.4")]),
+            Some("203.0.113.9"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn reads_the_client_through_a_trusted_peer() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "203.0.113.9")]),
+            Some("10.0.0.1"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn skips_trusted_hops_on_the_right() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "203.0.113.9, 10.0.0.7, 10.0.0.1")]),
+            Some("10.0.0.1"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn ignores_a_spoofed_prefix() {
+        // The client claims 1.1.1.1. The proxy appended the real address, so the
+        // rightmost untrusted entry wins.
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "1.1.1.1, 203.0.113.9, 10.0.0.1")]),
+            Some("10.0.0.1"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn keeps_an_internal_client_when_every_hop_is_trusted() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "10.0.0.55, 10.0.0.1")]),
+            Some("10.0.0.1"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("10.0.0.55"));
+    }
+
+    #[test]
+    fn falls_back_to_x_real_ip_behind_a_trusted_peer() {
+        let resolved = resolve(
+            &headers(&[("x-real-ip", "203.0.113.9")]),
+            Some("10.0.0.1"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn falls_back_to_the_peer_when_headers_are_junk() {
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "not-an-ip")]),
+            Some("10.0.0.1"),
+            &cidrs(&["10.0.0.0/8"]),
+        );
+        assert_eq!(resolved.as_deref(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn normalizes_an_ipv4_mapped_peer_to_one_bucket() {
+        let plain = resolve(&headers(&[]), Some("10.0.0.1"), &[]);
+        let mapped = resolve(&headers(&[]), Some("::ffff:10.0.0.1"), &[]);
+        assert_eq!(plain, mapped);
+    }
+
+    #[test]
+    fn returns_none_without_a_peer_or_usable_header() {
+        assert_eq!(resolve(&headers(&[]), None, &[]), None);
+    }
+}

--- a/crates/bolt-core/src/middleware/client_ip.rs
+++ b/crates/bolt-core/src/middleware/client_ip.rs
@@ -53,6 +53,19 @@ impl IpCidr {
             ));
         }
 
+        // `::ffff:a.b.c.d/n` with n >= 96 is an IPv4 block. Peers are
+        // normalized to IPv4, so store it as one or it never matches.
+        if let IpAddr::V6(v6) = network {
+            if prefix_len >= 96 {
+                if let Some(v4) = v6.to_ipv4_mapped() {
+                    return Ok(IpCidr {
+                        network: IpAddr::V4(v4),
+                        prefix_len: prefix_len - 96,
+                    });
+                }
+            }
+        }
+
         Ok(IpCidr {
             network,
             prefix_len,
@@ -61,8 +74,8 @@ impl IpCidr {
 
     /// Report whether `candidate` is inside this block.
     ///
-    /// An IPv4 block matches an IPv4-mapped IPv6 peer. An explicitly configured
-    /// IPv4-mapped IPv6 block remains IPv6, preserving its prefix length.
+    /// An IPv4 block matches an IPv4-mapped IPv6 peer. An IPv6 block that is
+    /// wider than the mapped range stays IPv6 and never matches IPv4.
     pub fn contains(&self, candidate: &IpAddr) -> bool {
         match self.network {
             IpAddr::V4(network) => match normalize(*candidate) {
@@ -350,10 +363,30 @@ mod tests {
     }
 
     #[test]
-    fn accepts_an_explicit_ipv4_mapped_ipv6_proxy() {
-        let block = IpCidr::parse("::ffff:10.0.0.0/104").unwrap();
-        assert!(block.contains(&"::ffff:10.1.2.3".parse().unwrap()));
-        assert!(!block.contains(&"::ffff:11.1.2.3".parse().unwrap()));
+    fn an_ipv4_mapped_block_trusts_the_ipv4_peer() {
+        // `::ffff:10.0.0.0/104` is `10.0.0.0/8`. The peer arrives as IPv4.
+        let trusted = proxies(&["::ffff:10.0.0.0/104"]);
+        let resolved = resolve(
+            &headers(&[("x-forwarded-for", "203.0.113.9")]),
+            Some("10.0.0.1"),
+            &trusted,
+        );
+        assert_eq!(resolved.as_deref(), Some("203.0.113.9"));
+
+        let outside = resolve(
+            &headers(&[("x-forwarded-for", "203.0.113.9")]),
+            Some("11.0.0.1"),
+            &trusted,
+        );
+        assert_eq!(outside.as_deref(), Some("11.0.0.1"));
+    }
+
+    #[test]
+    fn an_ipv4_mapped_block_narrower_than_the_mapped_prefix_stays_ipv6() {
+        // `/64` covers more than the mapped range, so it is a real IPv6 block.
+        let block = IpCidr::parse("::ffff:0:0/64").unwrap();
+        assert!(block.contains(&"::ffff:0:0:1".parse().unwrap()));
+        assert!(!block.contains(&"10.0.0.1".parse().unwrap()));
     }
 
     #[test]

--- a/crates/bolt-core/src/middleware/mod.rs
+++ b/crates/bolt-core/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod client_ip;
 pub mod compression;
 pub mod cors;
 pub mod rate_limit;

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -35,8 +35,11 @@ impl fmt::Display for LimiterKey {
     }
 }
 
-// Store per-key limiters
-static IP_LIMITERS: Lazy<DashMap<(usize, LimiterKey), Arc<Limiter>>> = Lazy::new(DashMap::new);
+/// Per-key limiters. The quota is part of the identity: handler ids are reused
+/// after a reload or by the next test app, and a stale limiter must not keep
+/// an old quota alive.
+static IP_LIMITERS: Lazy<DashMap<(usize, u32, u32, LimiterKey), Arc<Limiter>>> =
+    Lazy::new(DashMap::new);
 
 // Track total limiter count for cleanup
 static LIMITER_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -87,16 +90,18 @@ pub fn check_rate_limit(
     }
 
     // Get or create rate limiter for this handler + key combination
-    let limiter = IP_LIMITERS.entry((handler_id, key)).or_insert_with(|| {
-        // Increment counter
-        LIMITER_COUNT.fetch_add(1, Ordering::Relaxed);
+    let limiter = IP_LIMITERS
+        .entry((handler_id, rps, burst, key))
+        .or_insert_with(|| {
+            // Increment counter
+            LIMITER_COUNT.fetch_add(1, Ordering::Relaxed);
 
-        // Use NonZero constructors properly
-        let rps_nonzero = std::num::NonZeroU32::new(rps.max(1)).unwrap();
-        let burst_nonzero = std::num::NonZeroU32::new(burst.max(1)).unwrap();
-        let quota = Quota::per_second(rps_nonzero).allow_burst(burst_nonzero);
-        Arc::new(RateLimiter::direct(quota))
-    });
+            // Use NonZero constructors properly
+            let rps_nonzero = std::num::NonZeroU32::new(rps.max(1)).unwrap();
+            let burst_nonzero = std::num::NonZeroU32::new(burst.max(1)).unwrap();
+            let quota = Quota::per_second(rps_nonzero).allow_burst(burst_nonzero);
+            Arc::new(RateLimiter::direct(quota))
+        });
 
     // Check rate limit
     match limiter.check() {
@@ -109,7 +114,7 @@ pub fn check_rate_limit(
             // Log rate limit exceeded
             eprintln!(
                 "[django-bolt] Rate limit exceeded: {} {} | key: {} | limit: {} rps (burst: {}) | retry after: {}s",
-                method, path, limiter.key().1, rps, burst, retry_after
+                method, path, limiter.key().3, rps, burst, retry_after
             );
 
             Some(response_builder::build_rate_limit_response(

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -5,18 +5,38 @@ use governor::clock::{Clock, DefaultClock};
 use governor::state::{InMemoryState, NotKeyed};
 use governor::{Quota, RateLimiter};
 use once_cell::sync::Lazy;
+use std::fmt;
+use std::net::IpAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crate::metadata::RateLimitConfig;
-use crate::middleware::client_ip;
+use crate::metadata::{RateLimitConfig, RateLimitKey};
 use crate::response_builder;
 use crate::responses;
 
 type Limiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
 
-// Store per-key limiters (IP-based)
-static IP_LIMITERS: Lazy<DashMap<(usize, String), Arc<Limiter>>> = Lazy::new(DashMap::new);
+/// One bucket identity. `Ip` is `Copy`, so the common path hashes 17 bytes
+/// and never allocates. `Header` owns its value because it is the map key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum LimiterKey {
+    Ip(IpAddr),
+    Header(Box<str>),
+    Unknown,
+}
+
+impl fmt::Display for LimiterKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LimiterKey::Ip(ip) => ip.fmt(f),
+            LimiterKey::Header(value) => f.write_str(value),
+            LimiterKey::Unknown => f.write_str("unknown"),
+        }
+    }
+}
+
+// Store per-key limiters
+static IP_LIMITERS: Lazy<DashMap<(usize, LimiterKey), Arc<Limiter>>> = Lazy::new(DashMap::new);
 
 // Track total limiter count for cleanup
 static LIMITER_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -30,7 +50,7 @@ const MAX_KEY_LENGTH: usize = 256;
 pub fn check_rate_limit(
     handler_id: usize,
     headers: &AHashMap<String, String>,
-    peer_addr: Option<&str>,
+    client_ip: Option<&IpAddr>,
     config: &RateLimitConfig,
     method: &str,
     path: &str,
@@ -38,36 +58,26 @@ pub fn check_rate_limit(
     // Config is already parsed at startup - no GIL needed!
     let rps = config.rps;
     let burst = config.burst;
-    let key_type = &config.key_type;
 
     // Determine the rate limit key
-    let key = match key_type.as_str() {
-        "ip" => {
-            // SECURITY: a forwarding header is client input. `client_ip::resolve`
-            // reads one only when a declared trusted proxy sent it. See
-            // `client_ip` for the rules and `BOLT_TRUSTED_PROXIES` for the list.
-            client_ip::resolve(headers, peer_addr, &config.trusted_proxies)
-                .unwrap_or_else(|| "unknown".to_string())
-        }
-        header_name => {
-            // Custom header key — already lowercased once at startup when the
-            // RateLimitConfig was parsed (headers map stores lowercase names).
-            headers
-                .get(header_name)
-                .cloned()
-                .unwrap_or_else(|| "unknown".to_string())
-        }
-    };
-
-    // SECURITY: Validate key length to prevent memory attacks
-    if key.len() > MAX_KEY_LENGTH {
-        // Truncate or reject long keys
-        return Some(
-            HttpResponse::BadRequest()
-                .content_type("application/json")
-                .body(r#"{"detail":"Rate limit key too long"}"#),
-        );
+    let key = match &config.key {
+        RateLimitKey::Ip => client_ip.map(|ip| LimiterKey::Ip(*ip)),
+        // Custom header key — already lowercased once at startup when the
+        // RateLimitConfig was parsed (headers map stores lowercase names).
+        RateLimitKey::Header(name) => match headers.get(name) {
+            // SECURITY: Validate key length to prevent memory attacks
+            Some(value) if value.len() > MAX_KEY_LENGTH => {
+                return Some(
+                    HttpResponse::BadRequest()
+                        .content_type("application/json")
+                        .body(r#"{"detail":"Rate limit key too long"}"#),
+                );
+            }
+            Some(value) => Some(LimiterKey::Header(value.as_str().into())),
+            None => None,
+        },
     }
+    .unwrap_or(LimiterKey::Unknown);
 
     // SECURITY: Check if we've exceeded max limiters (prevent memory exhaustion)
     let current_count = LIMITER_COUNT.load(Ordering::Relaxed);
@@ -77,8 +87,7 @@ pub fn check_rate_limit(
     }
 
     // Get or create rate limiter for this handler + key combination
-    let limiter_key = (handler_id, key.clone());
-    let limiter = IP_LIMITERS.entry(limiter_key.clone()).or_insert_with(|| {
+    let limiter = IP_LIMITERS.entry((handler_id, key)).or_insert_with(|| {
         // Increment counter
         LIMITER_COUNT.fetch_add(1, Ordering::Relaxed);
 
@@ -100,7 +109,7 @@ pub fn check_rate_limit(
             // Log rate limit exceeded
             eprintln!(
                 "[django-bolt] Rate limit exceeded: {} {} | key: {} | limit: {} rps (burst: {}) | retry after: {}s",
-                method, path, key, rps, burst, retry_after
+                method, path, limiter.key().1, rps, burst, retry_after
             );
 
             Some(response_builder::build_rate_limit_response(

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::metadata::RateLimitConfig;
+use crate::middleware::client_ip;
 use crate::response_builder;
 use crate::responses;
 
@@ -42,17 +43,10 @@ pub fn check_rate_limit(
     // Determine the rate limit key
     let key = match key_type.as_str() {
         "ip" => {
-            // Try to get client IP from headers (X-Forwarded-For, X-Real-IP, etc.)
-            headers
-                .get("x-forwarded-for")
-                .or_else(|| headers.get("x-real-ip"))
-                .or_else(|| headers.get("remote-addr"))
-                .map(|ip| {
-                    // Take first IP if comma-separated
-                    ip.split(',').next().unwrap_or(ip).trim().to_string()
-                })
-                // Fallback to peer_addr if headers are missing
-                .or_else(|| peer_addr.map(|s| s.to_string()))
+            // SECURITY: a forwarding header is client input. `client_ip::resolve`
+            // reads one only when a declared trusted proxy sent it. See
+            // `client_ip` for the rules and `BOLT_TRUSTED_PROXIES` for the list.
+            client_ip::resolve(headers, peer_addr, &config.trusted_proxies)
                 .unwrap_or_else(|| "unknown".to_string())
         }
         header_name => {

--- a/crates/bolt-core/src/request.rs
+++ b/crates/bolt-core/src/request.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyString};
 
 use std::borrow::Cow;
+use std::net::IpAddr;
 use std::sync::OnceLock;
 
 /// Parse host:port from Actix's connection_info().host()
@@ -67,8 +68,8 @@ pub struct PyRequest {
     pub conn_host: String,
     /// Scheme: "http" or "https" (from X-Forwarded-Proto or request)
     pub conn_scheme: String,
-    /// Remote address: client IP (from X-Forwarded-For, X-Real-IP, or peer)
-    pub conn_remote_addr: String,
+    /// Resolved client address. Formatted only when `META` is read.
+    pub conn_remote_addr: Option<IpAddr>,
 }
 
 impl PyRequest {
@@ -303,10 +304,13 @@ impl PyRequest {
         meta.set_item("SERVER_PORT", server_port.to_string())?;
         meta.set_item("SERVER_PROTOCOL", "HTTP/1.1")?;
 
-        // REMOTE_ADDR from Actix's connection_info().realip_remote_addr()
-        // Actix handles X-Forwarded-For, Forwarded header, and peer_addr fallback
-        meta.set_item("REMOTE_ADDR", &self.conn_remote_addr)?;
-        meta.set_item("REMOTE_HOST", &self.conn_remote_addr)?;
+        // REMOTE_ADDR comes from `middleware::client_ip::resolve`.
+        let remote_addr = self
+            .conn_remote_addr
+            .map(|address| address.to_string())
+            .unwrap_or_else(|| "127.0.0.1".to_string());
+        meta.set_item("REMOTE_ADDR", &remote_addr)?;
+        meta.set_item("REMOTE_HOST", &remote_addr)?;
 
         // SCRIPT_NAME is usually empty for Django apps
         meta.set_item("SCRIPT_NAME", "")?;

--- a/crates/bolt-core/src/state.rs
+++ b/crates/bolt-core/src/state.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::metadata::{CompressionConfig, CorsConfig, RouteMetadata, RouteMetadataStore};
+use crate::middleware::client_ip::TrustedProxies;
 use crate::router::Router;
 pub use bolt_loop::TASK_LOCALS;
 
@@ -94,6 +95,8 @@ pub struct AppState {
     pub global_cors_config: Option<CorsConfig>, // Global CORS configuration from Django settings
     pub cors_origin_regexes: Vec<Regex>,        // Compiled regex patterns for origin matching
     pub global_compression_config: Option<Arc<CompressionConfig>>, // Global compression configuration used by middleware
+    /// Deployment-wide forwarding-header trust policy.
+    pub trusted_proxies: Arc<TrustedProxies>,
     pub router: Option<Arc<Router>>, // Router (used by test infrastructure, optional in production)
     pub route_metadata: Option<Arc<RouteMetadataStore>>, // Route metadata (used by test infrastructure)
     pub asgi_mounts: Option<Arc<Vec<AsgiMount>>>, // ASGI mounts (tests). Production uses GLOBAL_ASGI_MOUNTS.

--- a/crates/bolt-websocket/src/handler.rs
+++ b/crates/bolt-websocket/src/handler.rs
@@ -502,17 +502,23 @@ pub async fn handle_websocket_upgrade_with_handler(
         }
     }
 
-    // Get peer address for rate limiting
-    let peer_addr = req.peer_addr().map(|addr| addr.ip().to_string());
-
     // Check rate limiting BEFORE origin validation (reuse HTTP rate limit)
     if let Some(route_metadata) = ROUTE_METADATA.get() {
         if let Some(route_meta) = route_metadata.get(handler_id) {
             if let Some(ref rate_config) = route_meta.rate_limit_config {
+                let client_ip = (rate_config.key == bolt_core::metadata::RateLimitKey::Ip)
+                    .then(|| {
+                        bolt_core::middleware::client_ip::resolve_from_headers(
+                            req.headers(),
+                            req.peer_addr().map(|address| address.ip()),
+                            &state.trusted_proxies,
+                        )
+                    })
+                    .flatten();
                 if let Some(response) = check_rate_limit(
                     handler_id,
                     &headers,
-                    peer_addr.as_deref(),
+                    client_ip.as_ref(),
                     rate_config,
                     req.method().as_str(),
                     req.path(),

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -67,6 +67,27 @@ Preflight cache duration in seconds.
 CORS_MAX_AGE = 86400  # 24 hours
 ```
 
+## Rate limiting settings
+
+### BOLT_TRUSTED_PROXIES
+
+Proxies that sit in front of Bolt, as addresses or CIDR blocks. The list is empty by default.
+
+```python
+BOLT_TRUSTED_PROXIES = ["10.0.0.0/8"]
+```
+
+A `@rate_limit(key="ip")` limit uses this list to find the client address:
+
+- The list is empty. Bolt keys on the peer address of the connection and ignores every forwarding header.
+- The peer is not in the list. Bolt keys on the peer address. That peer is not a declared proxy, so its headers prove nothing.
+- The peer is in the list. Bolt reads `X-Forwarded-For` from the right and takes the first entry that is not a listed proxy. It falls back to `X-Real-IP`, then `Remote-Addr`, then the peer address.
+
+Both an address and a block are accepted. `127.0.0.1` matches one address. `10.0.0.0/8` matches the block. An invalid entry raises `ImproperlyConfigured` at startup.
+
+!!! warning "Set this when you run behind a proxy"
+    A client sends `X-Forwarded-For` itself, and a proxy appends to it. Without this setting Bolt ignores the header, so every caller behind the proxy shares one bucket. With the setting, Bolt separates them again and a client cannot pick its own bucket.
+
 ## File upload settings
 
 ### BOLT_MAX_UPLOAD_SIZE

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -77,11 +77,12 @@ Proxies that sit in front of Bolt, as addresses or CIDR blocks. The list is empt
 BOLT_TRUSTED_PROXIES = ["10.0.0.0/8"]
 ```
 
-A `@rate_limit(key="ip")` limit uses this list to find the client address:
+Bolt uses this list to find the canonical client address for
+`@rate_limit(key="ip")` and `request.META["REMOTE_ADDR"]`:
 
 - The list is empty. Bolt keys on the peer address of the connection and ignores every forwarding header.
 - The peer is not in the list. Bolt keys on the peer address. That peer is not a declared proxy, so its headers prove nothing.
-- The peer is in the list. Bolt reads `X-Forwarded-For` from the right and takes the first entry that is not a listed proxy. It falls back to `X-Real-IP`, then `Remote-Addr`, then the peer address.
+- The peer is in the list. Bolt reads `X-Forwarded-For` from the right and takes the first entry that is not a listed proxy. It falls back to a valid `X-Real-IP`, then the peer address. A malformed chain also falls back to the peer.
 
 Both an address and a block are accepted. `127.0.0.1` matches one address. `10.0.0.0/8` matches the block. An invalid entry raises `ImproperlyConfigured` at startup.
 

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -82,7 +82,7 @@ Bolt uses this list to find the canonical client address for
 
 - The list is empty. Bolt keys on the peer address of the connection and ignores every forwarding header.
 - The peer is not in the list. Bolt keys on the peer address. That peer is not a declared proxy, so its headers prove nothing.
-- The peer is in the list. Bolt reads `X-Forwarded-For` from the right and takes the first entry that is not a listed proxy. It falls back to a valid `X-Real-IP`, then the peer address. A malformed chain also falls back to the peer.
+- The peer is in the list. Bolt reads `X-Forwarded-For` from the right and takes the first entry that is not a listed proxy. When every entry is a listed proxy, the client is inside your network and Bolt takes the leftmost entry. Without the header, Bolt falls back to a valid `X-Real-IP`, then the peer address. A malformed chain also falls back to the peer.
 
 Both an address and a block are accepted. `127.0.0.1` matches one address. `10.0.0.0/8` matches the block. An invalid entry raises `ImproperlyConfigured` at startup.
 

--- a/docs/src/topics/middleware.md
+++ b/docs/src/topics/middleware.md
@@ -90,6 +90,10 @@ Bolt then reads `X-Forwarded-For` from the right and takes the first entry that
 is not a listed proxy. A client cannot pick its own bucket, because the proxy
 appends the real address to the right of anything the client sent.
 
+The resolved address is also exposed as `request.META["REMOTE_ADDR"]`. If any
+forwarding hop is malformed, Bolt ignores the chain and uses the connection
+peer rather than searching farther left through client-controlled input.
+
 Set this whenever a proxy, a load balancer or a CDN is in front of Bolt.
 Without it every caller behind that proxy shares one bucket. See
 [BOLT_TRUSTED_PROXIES](../ref/settings.md#bolt_trusted_proxies).

--- a/docs/src/topics/middleware.md
+++ b/docs/src/topics/middleware.md
@@ -72,6 +72,27 @@ Parameters:
 
 - `rps` - Requests per second allowed
 - `burst` - Maximum burst size (allows short spikes)
+- `key` - What to count per (`"ip"` by default)
+
+### Client address behind a proxy
+
+With `key="ip"`, Bolt keys on the peer address of the connection. A client sends
+`X-Forwarded-For` itself, so Bolt ignores that header by default.
+
+Declare your proxies to make the header trustworthy:
+
+```python
+# settings.py
+BOLT_TRUSTED_PROXIES = ["10.0.0.0/8"]
+```
+
+Bolt then reads `X-Forwarded-For` from the right and takes the first entry that
+is not a listed proxy. A client cannot pick its own bucket, because the proxy
+appends the real address to the right of anything the client sent.
+
+Set this whenever a proxy, a load balancer or a CDN is in front of Bolt.
+Without it every caller behind that proxy shares one bucket. See
+[BOLT_TRUSTED_PROXIES](../ref/settings.md#bolt_trusted_proxies).
 
 ### How it works
 

--- a/python/django_bolt/logging/middleware.py
+++ b/python/django_bolt/logging/middleware.py
@@ -119,13 +119,14 @@ class LoggingMiddleware:
                     data["body"] = f"<binary data, {len(body)} bytes>"
 
         if "client_ip" in self.config.request_log_fields:
-            # Try to get client IP from various headers
+            # Runtime requests expose Bolt's canonical, proxy-aware address via
+            # Django's existing REMOTE_ADDR. The header fallback is only for
+            # standalone dict inputs used outside Bolt's request pipeline.
             headers = request.get("headers", {})
-            client_ip = (
-                headers.get("x-forwarded-for", "").split(",")[0].strip()
-                or headers.get("x-real-ip", "")
-                or request.get("client", "")
-            )
+            meta = getattr(request, "META", None)
+            client_ip = meta.get("REMOTE_ADDR", "") if meta is not None else ""
+            if not client_ip and meta is None:
+                client_ip = headers.get("x-forwarded-for", "").split(",")[0].strip() or headers.get("x-real-ip", "")
             if client_ip:
                 data["client_ip"] = client_ip
 

--- a/python/django_bolt/middleware/compiler.py
+++ b/python/django_bolt/middleware/compiler.py
@@ -445,8 +445,8 @@ def get_trusted_proxies() -> list[str]:
         Normalized CIDR strings, for example `["10.0.0.0/8", "127.0.0.1/32"]`.
 
     Raises:
-        ImproperlyConfigured: The setting is not a list, or an entry is not an
-            address or a CIDR block.
+        ImproperlyConfigured: The setting is not a list or a tuple, or an entry
+            is not an address or a CIDR block.
     """
     configured = getattr(settings, "BOLT_TRUSTED_PROXIES", None)
     if configured is None:

--- a/python/django_bolt/middleware/compiler.py
+++ b/python/django_bolt/middleware/compiler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import inspect
+import ipaddress
 import uuid
 from collections.abc import Callable
 from typing import Annotated, Any, get_args, get_origin
@@ -181,6 +182,12 @@ def compile_middleware_meta(
 
     if all_middleware:
         result["middleware"] = all_middleware
+
+        # Rust needs the trusted proxy list to resolve the client address for a
+        # `key="ip"` rate limit. Proxies belong to the deployment, not to one
+        # route, so resolve the setting once here at registration.
+        if any(mw.get("type") == "rate_limit" for mw in all_middleware):
+            result["trusted_proxies"] = get_trusted_proxies()
 
     # Always include skip flags if present (even without middleware/auth/guards)
     if skip_middleware:
@@ -423,6 +430,44 @@ def add_optimization_flags_to_metadata(metadata: dict[str, Any] | None, handler_
     metadata["memory_spool_threshold"] = getattr(settings, "BOLT_MEMORY_SPOOL_THRESHOLD", 1024 * 1024)
 
     return metadata
+
+
+def get_trusted_proxies() -> list[str]:
+    """
+    Read and validate `settings.BOLT_TRUSTED_PROXIES`.
+
+    The setting holds the proxies that sit in front of Bolt, as addresses or
+    CIDR blocks. A `key="ip"` rate limit believes `X-Forwarded-For` only from a
+    peer in this list. The list is empty by default, so Bolt keys on the peer
+    address and ignores forwarding headers.
+
+    Returns:
+        Normalized CIDR strings, for example `["10.0.0.0/8", "127.0.0.1/32"]`.
+
+    Raises:
+        ImproperlyConfigured: An entry is not an address or a CIDR block.
+    """
+    configured = getattr(settings, "BOLT_TRUSTED_PROXIES", None)
+    # Check the raw value. Normalizing first would turn an empty string into an
+    # empty list, and a typo that empties the setting must not read as "no
+    # proxies declared".
+    if isinstance(configured, str):
+        raise ImproperlyConfigured(
+            f"BOLT_TRUSTED_PROXIES must be a list of addresses or CIDR blocks, got the string {configured!r}."
+        )
+    if not configured:
+        return []
+
+    normalized = []
+    for entry in configured:
+        try:
+            network = ipaddress.ip_network(entry, strict=False)
+        except (TypeError, ValueError) as e:
+            raise ImproperlyConfigured(
+                f"BOLT_TRUSTED_PROXIES entry {entry!r} is not an address or CIDR block: {e}"
+            ) from e
+        normalized.append(str(network))
+    return normalized
 
 
 def middleware_to_dict(mw: Any) -> dict[str, Any] | None:

--- a/python/django_bolt/middleware/compiler.py
+++ b/python/django_bolt/middleware/compiler.py
@@ -445,18 +445,22 @@ def get_trusted_proxies() -> list[str]:
         Normalized CIDR strings, for example `["10.0.0.0/8", "127.0.0.1/32"]`.
 
     Raises:
-        ImproperlyConfigured: An entry is not an address or a CIDR block.
+        ImproperlyConfigured: The setting is not a list, or an entry is not an
+            address or a CIDR block.
     """
     configured = getattr(settings, "BOLT_TRUSTED_PROXIES", None)
-    # Check the raw value. Normalizing first would turn an empty string into an
-    # empty list, and a typo that empties the setting must not read as "no
-    # proxies declared".
-    if isinstance(configured, str):
-        raise ImproperlyConfigured(
-            f"BOLT_TRUSTED_PROXIES must be a list of addresses or CIDR blocks, got the string {configured!r}."
-        )
-    if not configured:
+    if configured is None:
         return []
+
+    # Check the type before the loop reads it. A string iterates one character
+    # at a time, a mapping iterates its keys, and anything else raises a bare
+    # TypeError from inside the loop. All three are configuration mistakes, and
+    # the two that iterate would otherwise produce a silently wrong proxy list.
+    if not isinstance(configured, (list, tuple)):
+        raise ImproperlyConfigured(
+            f"BOLT_TRUSTED_PROXIES must be a list of addresses or CIDR blocks, "
+            f"got {type(configured).__name__} {configured!r}."
+        )
 
     normalized = []
     for entry in configured:

--- a/python/django_bolt/middleware/compiler.py
+++ b/python/django_bolt/middleware/compiler.py
@@ -183,12 +183,6 @@ def compile_middleware_meta(
     if all_middleware:
         result["middleware"] = all_middleware
 
-        # Rust needs the trusted proxy list to resolve the client address for a
-        # `key="ip"` rate limit. Proxies belong to the deployment, not to one
-        # route, so resolve the setting once here at registration.
-        if any(mw.get("type") == "rate_limit" for mw in all_middleware):
-            result["trusted_proxies"] = get_trusted_proxies()
-
     # Always include skip flags if present (even without middleware/auth/guards)
     if skip_middleware:
         result["skip"] = list(skip_middleware)
@@ -437,9 +431,9 @@ def get_trusted_proxies() -> list[str]:
     Read and validate `settings.BOLT_TRUSTED_PROXIES`.
 
     The setting holds the proxies that sit in front of Bolt, as addresses or
-    CIDR blocks. A `key="ip"` rate limit believes `X-Forwarded-For` only from a
-    peer in this list. The list is empty by default, so Bolt keys on the peer
-    address and ignores forwarding headers.
+    CIDR blocks. Bolt believes `X-Forwarded-For` only from a peer in this list.
+    The list is empty by default, so Bolt uses the peer address and ignores
+    forwarding headers.
 
     Returns:
         Normalized CIDR strings, for example `["10.0.0.0/8", "127.0.0.1/32"]`.
@@ -464,6 +458,13 @@ def get_trusted_proxies() -> list[str]:
 
     normalized = []
     for entry in configured:
+        # `ip_network` also accepts an int and turns 10 into 0.0.0.10/32.
+        # That is a silently wrong proxy, so accept only strings.
+        if not isinstance(entry, str):
+            raise ImproperlyConfigured(
+                f"BOLT_TRUSTED_PROXIES entry {entry!r} is not an address or CIDR block: "
+                f"expected a string, got {type(entry).__name__}."
+            )
         try:
             network = ipaddress.ip_network(entry, strict=False)
         except (TypeError, ValueError) as e:

--- a/python/django_bolt/middleware/middleware.py
+++ b/python/django_bolt/middleware/middleware.py
@@ -398,6 +398,16 @@ def rate_limit(rps: int = 100, burst: int | None = None, key: str = "ip"):
     This middleware is handled in Rust for maximum performance.
     No Python overhead in the hot path.
 
+    With `key="ip"`, Bolt keys on the peer address of the connection. A client
+    can send `X-Forwarded-For` itself, so Bolt ignores that header by default.
+    Behind a proxy, list the proxy in `settings.BOLT_TRUSTED_PROXIES`:
+
+        BOLT_TRUSTED_PROXIES = ["10.0.0.0/8"]
+
+    Bolt then reads `X-Forwarded-For` from the right and takes the first entry
+    that is not a listed proxy. Without the setting, every caller behind the
+    proxy shares one bucket.
+
     Args:
         rps: Requests per second limit
         burst: Burst capacity (defaults to 2x rps)

--- a/python/tests/integration/apps/rate_limit_client_ip.py
+++ b/python/tests/integration/apps/rate_limit_client_ip.py
@@ -1,8 +1,8 @@
-"""App under test for how a `key="ip"` rate limit picks the client address."""
+"""App under test for how a rate limit picks its bucket key."""
 
 from __future__ import annotations
 
-from django_bolt import BoltAPI
+from django_bolt import BoltAPI, Request
 from django_bolt.middleware import rate_limit
 
 api = BoltAPI()
@@ -21,3 +21,14 @@ async def health():
 @rate_limit(rps=1, burst=BURST, key="ip")
 async def limited():
     return {"ok": True}
+
+
+@api.get("/limited-by-header")
+@rate_limit(rps=1, burst=BURST, key="X-Tenant")
+async def limited_by_header():
+    return {"ok": True}
+
+
+@api.get("/remote-addr")
+async def remote_addr(request: Request):
+    return {"remote_addr": request.META["REMOTE_ADDR"]}

--- a/python/tests/integration/apps/rate_limit_client_ip.py
+++ b/python/tests/integration/apps/rate_limit_client_ip.py
@@ -1,0 +1,23 @@
+"""App under test for how a `key="ip"` rate limit picks the client address."""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI
+from django_bolt.middleware import rate_limit
+
+api = BoltAPI()
+
+# Small enough to exhaust in a few requests, slow enough to refill that the
+# refill cannot hide a missing limit between two calls.
+BURST = 4
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/limited")
+@rate_limit(rps=1, burst=BURST, key="ip")
+async def limited():
+    return {"ok": True}

--- a/python/tests/integration/test_rate_limit_client_ip_server_integration.py
+++ b/python/tests/integration/test_rate_limit_client_ip_server_integration.py
@@ -1,15 +1,12 @@
-"""Real-server tests for how a `key="ip"` rate limit picks the client address.
+"""Real-server tests for how a rate limit picks its bucket key.
 
 These run against an actual ``runbolt`` process over TCP, which is the only way
 to give the limit a real peer address. The in-process ``TestClient`` builds its
 request with ``TestRequest``, which leaves ``peer_addr`` unset, so every caller
-resolves to the same constant and no proxy can ever be trusted. Configuration
-errors, which need no peer, are covered in
-``python/tests/test_rate_limit_client_ip.py``.
+resolves to the same constant and no proxy can ever be trusted.
 
-``BOLT_TRUSTED_PROXIES`` is read once per process at route registration, so the
-trusting case and the strict case need one server each. Everything else shares
-those two.
+``BOLT_TRUSTED_PROXIES`` is read once per process at server startup, so each
+trust setting needs one server. The tests for one setting share that server.
 """
 
 from __future__ import annotations
@@ -21,31 +18,91 @@ from .apps.rate_limit_client_ip import BURST
 
 pytestmark = pytest.mark.server_integration
 
-# RFC 5737 documentation addresses, so nothing here looks routable.
+# RFC 5737 and RFC 3849 documentation addresses, so nothing here looks routable.
 CALLER = "203.0.113.10"
 OTHER_CALLER = "203.0.113.11"
+THIRD_CALLER = "203.0.113.12"
+CALLER_V6 = "2001:db8::9"
+PEER = "127.0.0.1"
+
+APP = app_module("rate_limit_client_ip")
+TRUST_LOOPBACK = 'BOLT_TRUSTED_PROXIES = ["127.0.0.0/8"]'
 
 
-def _exhaust(server, forwarded_for):
+def _exhaust(server, path="/limited", **headers):
     """Spend the bucket for one caller. Return the last status code."""
     status = None
     for _ in range(BURST + 2):
-        status = server.request("GET", "/limited", headers={"X-Forwarded-For": forwarded_for}).status_code
+        status = server.request("GET", path, headers=headers).status_code
     return status
 
 
-def test_forwarded_for_cannot_reset_the_bucket_without_a_trusted_proxy(make_server_project):
+def _remote_addr(server, headers):
+    response = server.request("GET", "/remote-addr", headers=headers)
+    assert response.status_code == 200, response.text
+    return response.json()["remote_addr"]
+
+
+# ---------------------------------------------------------------------------
+# Default: no trusted proxy
+# ---------------------------------------------------------------------------
+
+
+def test_without_a_trusted_proxy_every_forwarding_header_is_ignored(make_server_project):
     """A client must not buy a new bucket by changing one header."""
-    project = make_server_project(api_module=app_module("rate_limit_client_ip"))
+    project = make_server_project(api_module=APP)
 
     with project.start() as server:
-        assert _exhaust(server, CALLER) == 429
+        # REMOTE_ADDR is the peer no matter what the headers say.
+        assert _remote_addr(server, {"X-Forwarded-For": CALLER}) == PEER
+        assert _remote_addr(server, {"X-Real-IP": CALLER}) == PEER
+
+        assert _exhaust(server, **{"X-Forwarded-For": CALLER}) == 429
 
         # Both callers reach the server from the same address, so the limit
         # still applies no matter what the header says.
-        response = server.request("GET", "/limited", headers={"X-Forwarded-For": OTHER_CALLER})
+        forwarded = server.request("GET", "/limited", headers={"X-Forwarded-For": OTHER_CALLER})
+        real_ip = server.request("GET", "/limited", headers={"X-Real-IP": OTHER_CALLER})
+        bare = server.request("GET", "/limited")
 
-    assert response.status_code == 429, response.text
+    assert forwarded.status_code == 429, forwarded.text
+    assert real_ip.status_code == 429, real_ip.text
+    assert bare.status_code == 429, bare.text
+
+
+def test_a_header_key_buckets_on_the_header_value(make_server_project):
+    """``key="X-Tenant"`` buckets on that header and ignores the address."""
+    project = make_server_project(api_module=APP)
+
+    with project.start() as server:
+        assert _exhaust(server, "/limited-by-header", **{"X-Tenant": "acme"}) == 429
+
+        other_tenant = server.request("GET", "/limited-by-header", headers={"X-Tenant": "globex"})
+        # Header names are matched without regard to case.
+        same_tenant = server.request("GET", "/limited-by-header", headers={"x-tenant": "acme"})
+
+        # Callers that send no header share one bucket.
+        assert _exhaust(server, "/limited-by-header") == 429
+        missing_again = server.request("GET", "/limited-by-header")
+
+        # The header route and the address route keep separate buckets.
+        by_ip = server.request("GET", "/limited")
+
+        too_long = server.request("GET", "/limited-by-header", headers={"X-Tenant": "t" * 257})
+        longest_allowed = server.request("GET", "/limited-by-header", headers={"X-Tenant": "u" * 256})
+
+    assert other_tenant.status_code == 200, other_tenant.text
+    assert same_tenant.status_code == 429, same_tenant.text
+    assert missing_again.status_code == 429, missing_again.text
+    assert by_ip.status_code == 200, by_ip.text
+    assert too_long.status_code == 400, too_long.text
+    assert too_long.json() == {"detail": "Rate limit key too long"}
+    assert longest_allowed.status_code == 200, longest_allowed.text
+
+
+# ---------------------------------------------------------------------------
+# Trusted proxy that covers the peer
+# ---------------------------------------------------------------------------
 
 
 def test_a_trusted_proxy_makes_the_header_usable_again(make_server_project):
@@ -55,15 +112,12 @@ def test_a_trusted_proxy_makes_the_header_usable_again(make_server_project):
     Spinning a second ``runbolt`` for the spoof check is not worth the port
     pressure, and both halves read the same setting.
     """
-    project = make_server_project(
-        api_module=app_module("rate_limit_client_ip"),
-        settings_extra='BOLT_TRUSTED_PROXIES = ["127.0.0.0/8"]',
-    )
+    project = make_server_project(api_module=APP, settings_extra=TRUST_LOOPBACK)
 
     with project.start() as server:
         # The peer is 127.0.0.1 and the setting covers it, so the client is
         # CALLER: the rightmost entry that is not a declared proxy.
-        assert _exhaust(server, CALLER) == 429
+        assert _exhaust(server, **{"X-Forwarded-For": CALLER}) == 429
 
         # A second caller through the same proxy gets its own bucket.
         allowed = server.request("GET", "/limited", headers={"X-Forwarded-For": OTHER_CALLER})
@@ -71,5 +125,136 @@ def test_a_trusted_proxy_makes_the_header_usable_again(make_server_project):
         # The first caller now invents a prefix. It resolves to the same bucket.
         spoofed = server.request("GET", "/limited", headers={"X-Forwarded-For": f"{OTHER_CALLER}, {CALLER}"})
 
+        # A caller that sends no header is keyed on the peer, a third bucket.
+        bare = server.request("GET", "/limited")
+
     assert allowed.status_code == 200, allowed.text
     assert spoofed.status_code == 429, spoofed.text
+    assert bare.status_code == 200, bare.text
+
+
+def test_remote_addr_follows_the_forwarding_rules(make_server_project):
+    """Django code and the limiter must agree on the canonical client IP."""
+    project = make_server_project(api_module=APP, settings_extra=TRUST_LOOPBACK)
+
+    with project.start() as server:
+        # Rule 3: rightmost entry that is not a trusted proxy.
+        assert _remote_addr(server, {"X-Forwarded-For": CALLER}) == CALLER
+        assert _remote_addr(server, {"X-Forwarded-For": f"{OTHER_CALLER}, {CALLER}, 127.0.0.7"}) == CALLER
+
+        # Rule 4: every entry is trusted, so the leftmost is the client.
+        assert _remote_addr(server, {"X-Forwarded-For": "127.0.0.55, 127.0.0.7"}) == "127.0.0.55"
+
+        # Rule 5: X-Real-IP is used when X-Forwarded-For is absent, not as a
+        # second opinion when it is present.
+        assert _remote_addr(server, {"X-Real-IP": CALLER}) == CALLER
+        assert _remote_addr(server, {"X-Forwarded-For": CALLER, "X-Real-IP": OTHER_CALLER}) == CALLER
+        assert _remote_addr(server, {"X-Real-IP": "attacker-chosen-bucket"}) == PEER
+
+        # Rule 6: a malformed hop never exposes an entry farther left.
+        assert _remote_addr(server, {"X-Forwarded-For": f"{OTHER_CALLER}, not-an-ip, 127.0.0.1"}) == PEER
+        assert _remote_addr(server, {"X-Forwarded-For": "not-an-ip"}) == PEER
+        assert _remote_addr(server, {"X-Forwarded-For": ""}) == PEER
+        assert _remote_addr(server, {"X-Forwarded-For": f"{CALLER},,127.0.0.1"}) == PEER
+
+        # Proxy output with a port is accepted for both families.
+        assert _remote_addr(server, {"X-Forwarded-For": f"{CALLER}:54321"}) == CALLER
+        assert _remote_addr(server, {"X-Forwarded-For": f"[{CALLER_V6}]:443"}) == CALLER_V6
+        assert _remote_addr(server, {"X-Forwarded-For": CALLER_V6}) == CALLER_V6
+
+        # An IPv4-mapped IPv6 entry normalizes to IPv4.
+        assert _remote_addr(server, {"X-Forwarded-For": f"::ffff:{CALLER}"}) == CALLER
+
+        # Whitespace around a comma does not matter.
+        assert _remote_addr(server, {"X-Forwarded-For": f"{CALLER}  ,  127.0.0.9"}) == CALLER
+
+
+def test_duplicate_forwarded_for_headers_are_read_in_wire_order(make_server_project):
+    """Two ``X-Forwarded-For`` headers form one chain, earlier header first."""
+    project = make_server_project(api_module=APP, settings_extra=TRUST_LOOPBACK)
+
+    with project.start() as server:
+        chain = [("X-Forwarded-For", f"{OTHER_CALLER}, {CALLER}"), ("X-Forwarded-For", "127.0.0.7")]
+        assert _remote_addr(server, chain) == CALLER
+
+        # A malformed hop in the later header hides the earlier header.
+        broken = [("X-Forwarded-For", OTHER_CALLER), ("X-Forwarded-For", "not-an-ip")]
+        assert _remote_addr(server, broken) == PEER
+
+        # The limiter keys on the same chain.
+        status = None
+        for _ in range(BURST + 2):
+            status = server.request("GET", "/limited", headers=chain).status_code
+        assert status == 429
+        spoofed = server.request(
+            "GET", "/limited", headers=[("X-Forwarded-For", THIRD_CALLER), ("X-Forwarded-For", CALLER)]
+        )
+        fresh = server.request("GET", "/limited", headers=[("X-Forwarded-For", THIRD_CALLER)])
+
+    assert spoofed.status_code == 429, spoofed.text
+    assert fresh.status_code == 200, fresh.text
+
+
+def test_equivalent_addresses_share_one_bucket(make_server_project):
+    """One client, spelled three ways, is one bucket."""
+    project = make_server_project(api_module=APP, settings_extra=TRUST_LOOPBACK)
+
+    with project.start() as server:
+        assert _exhaust(server, **{"X-Forwarded-For": CALLER}) == 429
+        mapped = server.request("GET", "/limited", headers={"X-Forwarded-For": f"::ffff:{CALLER}"})
+        with_port = server.request("GET", "/limited", headers={"X-Forwarded-For": f"{CALLER}:4000"})
+        padded = server.request("GET", "/limited", headers={"X-Forwarded-For": f"{CALLER} , 127.0.0.9"})
+
+    assert mapped.status_code == 429, mapped.text
+    assert with_port.status_code == 429, with_port.text
+    assert padded.status_code == 429, padded.text
+
+
+# ---------------------------------------------------------------------------
+# Trusted proxy that does not cover the peer
+# ---------------------------------------------------------------------------
+
+
+def test_a_peer_outside_the_trusted_list_is_not_believed(make_server_project):
+    """The setting may be a tuple. A peer outside it proves nothing."""
+    project = make_server_project(api_module=APP, settings_extra='BOLT_TRUSTED_PROXIES = ("10.0.0.0/8", "::1")')
+
+    with project.start() as server:
+        assert _remote_addr(server, {"X-Forwarded-For": CALLER}) == PEER
+        assert _exhaust(server, **{"X-Forwarded-For": CALLER}) == 429
+        response = server.request("GET", "/limited", headers={"X-Forwarded-For": OTHER_CALLER})
+
+    assert response.status_code == 429, response.text
+
+
+def test_a_bare_address_entry_matches_only_itself(make_server_project):
+    """``127.0.0.2`` does not cover the peer ``127.0.0.1``."""
+    project = make_server_project(api_module=APP, settings_extra='BOLT_TRUSTED_PROXIES = ["127.0.0.2"]')
+
+    with project.start() as server:
+        assert _remote_addr(server, {"X-Forwarded-For": CALLER}) == PEER
+
+
+# ---------------------------------------------------------------------------
+# Startup validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "setting",
+    [
+        '["10.0.0.0/8", "not-an-ip"]',
+        '["10.0.0.0/33"]',
+        '["::1/129"]',
+        '["10.0.0.0/eight"]',
+        '"10.0.0.0/8"',
+        "[10]",
+    ],
+)
+def test_an_invalid_setting_aborts_startup(make_server_project, setting):
+    """A wrong list must stop the server, not run with a weaker limit."""
+    project = make_server_project(api_module=APP, settings_extra=f"BOLT_TRUSTED_PROXIES = {setting}")
+
+    with pytest.raises(AssertionError) as excinfo, project.start(timeout=15):
+        pass
+    assert "BOLT_TRUSTED_PROXIES" in str(excinfo.value)

--- a/python/tests/integration/test_rate_limit_client_ip_server_integration.py
+++ b/python/tests/integration/test_rate_limit_client_ip_server_integration.py
@@ -1,0 +1,75 @@
+"""Real-server tests for how a `key="ip"` rate limit picks the client address.
+
+These run against an actual ``runbolt`` process over TCP, which is the only way
+to give the limit a real peer address. The in-process ``TestClient`` builds its
+request with ``TestRequest``, which leaves ``peer_addr`` unset, so every caller
+resolves to the same constant and no proxy can ever be trusted. Configuration
+errors, which need no peer, are covered in
+``python/tests/test_rate_limit_client_ip.py``.
+
+``BOLT_TRUSTED_PROXIES`` is read once per process at route registration, so the
+trusting case and the strict case need one server each. Everything else shares
+those two.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .apps import app_module
+from .apps.rate_limit_client_ip import BURST
+
+pytestmark = pytest.mark.server_integration
+
+# RFC 5737 documentation addresses, so nothing here looks routable.
+CALLER = "203.0.113.10"
+OTHER_CALLER = "203.0.113.11"
+
+
+def _exhaust(server, forwarded_for):
+    """Spend the bucket for one caller. Return the last status code."""
+    status = None
+    for _ in range(BURST + 2):
+        status = server.request("GET", "/limited", headers={"X-Forwarded-For": forwarded_for}).status_code
+    return status
+
+
+def test_forwarded_for_cannot_reset_the_bucket_without_a_trusted_proxy(make_server_project):
+    """A client must not buy a new bucket by changing one header."""
+    project = make_server_project(api_module=app_module("rate_limit_client_ip"))
+
+    with project.start() as server:
+        assert _exhaust(server, CALLER) == 429
+
+        # Both callers reach the server from the same address, so the limit
+        # still applies no matter what the header says.
+        response = server.request("GET", "/limited", headers={"X-Forwarded-For": OTHER_CALLER})
+
+    assert response.status_code == 429, response.text
+
+
+def test_a_trusted_proxy_makes_the_header_usable_again(make_server_project):
+    """
+    One server covers both halves of the trusting case.
+
+    Spinning a second ``runbolt`` for the spoof check is not worth the port
+    pressure, and both halves read the same setting.
+    """
+    project = make_server_project(
+        api_module=app_module("rate_limit_client_ip"),
+        settings_extra='BOLT_TRUSTED_PROXIES = ["127.0.0.0/8"]',
+    )
+
+    with project.start() as server:
+        # The peer is 127.0.0.1 and the setting covers it, so the client is
+        # CALLER: the rightmost entry that is not a declared proxy.
+        assert _exhaust(server, CALLER) == 429
+
+        # A second caller through the same proxy gets its own bucket.
+        allowed = server.request("GET", "/limited", headers={"X-Forwarded-For": OTHER_CALLER})
+
+        # The first caller now invents a prefix. It resolves to the same bucket.
+        spoofed = server.request("GET", "/limited", headers={"X-Forwarded-For": f"{OTHER_CALLER}, {CALLER}"})
+
+    assert allowed.status_code == 200, allowed.text
+    assert spoofed.status_code == 429, spoofed.text

--- a/python/tests/test_logging.py
+++ b/python/tests/test_logging.py
@@ -345,6 +345,17 @@ class TestLoggingMiddleware:
         data = middleware.extract_request_data(request)
         assert data["client_ip"] == "192.168.1.2"
 
+    def test_extract_request_data_prefers_canonical_client_ip(self):
+        """Runtime REMOTE_ADDR must win over client-controlled headers."""
+        config = LoggingConfig(request_log_fields={"client_ip"})
+        middleware = LoggingMiddleware(config)
+        request_data = {"headers": {"x-forwarded-for": "1.1.1.1"}}
+        request = Mock()
+        request.get.side_effect = request_data.get
+        request.META = {"REMOTE_ADDR": "203.0.113.9"}
+
+        assert middleware.extract_request_data(request)["client_ip"] == "203.0.113.9"
+
     def test_extract_request_data_extracts_user_agent(self):
         """User agent should be extracted when configured."""
         config = LoggingConfig(request_log_fields={"user_agent"})

--- a/python/tests/test_rate_limit_client_ip.py
+++ b/python/tests/test_rate_limit_client_ip.py
@@ -1,0 +1,73 @@
+"""
+Tests for `settings.BOLT_TRUSTED_PROXIES`, the list that decides whether a
+`key="ip"` rate limit may believe `X-Forwarded-For`.
+
+Only the configuration half lives here. Everything that needs a real client
+address runs against a real server, in
+``python/tests/integration/test_rate_limit_client_ip_server_integration.py``:
+``TestRequest`` leaves ``peer_addr`` unset, so in process every caller resolves
+to the same constant and no proxy can be trusted.
+"""
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+from django_bolt import BoltAPI
+from django_bolt.middleware import rate_limit
+
+
+def _api_with_limited_route():
+    """Build an API with one route limited per IP."""
+    api = BoltAPI()
+
+    @api.get("/limited")
+    @rate_limit(rps=1, burst=4, key="ip")
+    async def limited():
+        return {"ok": True}
+
+    return api
+
+
+@pytest.mark.parametrize("entry", ["not-an-ip", "10.0.0.0/nine", "10.0.0.0/33", "::1/129"])
+def test_an_invalid_entry_fails_at_registration(entry):
+    """A typo stops startup instead of quietly widening a bucket."""
+    with (
+        override_settings(BOLT_TRUSTED_PROXIES=["10.0.0.0/8", entry]),
+        pytest.raises(ImproperlyConfigured, match="BOLT_TRUSTED_PROXIES"),
+    ):
+        _api_with_limited_route()
+
+
+@pytest.mark.parametrize("configured", ["10.0.0.0/8", ""])
+def test_a_string_setting_fails_at_registration(configured):
+    """
+    A bare string iterates one character at a time, so reject it by name.
+
+    The empty string counts. It is falsey, so a normalize-then-check order would
+    read it as an empty list and report no proxies at all.
+    """
+    with (
+        override_settings(BOLT_TRUSTED_PROXIES=configured),
+        pytest.raises(ImproperlyConfigured, match="must be a list"),
+    ):
+        _api_with_limited_route()
+
+
+@pytest.mark.parametrize("configured", [None, [], ["10.0.0.1"], ["10.0.0.0/8", "::1"]])
+def test_a_valid_setting_registers(configured):
+    """Addresses and blocks are both accepted, in either family."""
+    with override_settings(BOLT_TRUSTED_PROXIES=configured):
+        assert _api_with_limited_route() is not None
+
+
+def test_a_route_without_a_rate_limit_is_unaffected():
+    """Only a rate limited route reads the list, so only it should validate one."""
+    with override_settings(BOLT_TRUSTED_PROXIES=["not-an-ip"]):
+        api = BoltAPI()
+
+        @api.get("/plain")
+        async def plain():
+            return {"ok": True}
+
+        assert api is not None

--- a/python/tests/test_rate_limit_client_ip.py
+++ b/python/tests/test_rate_limit_client_ip.py
@@ -15,6 +15,7 @@ from django.test import override_settings
 
 from django_bolt import BoltAPI
 from django_bolt.middleware import rate_limit
+from django_bolt.testing import TestClient
 
 
 def _api_with_limited_route():
@@ -29,14 +30,14 @@ def _api_with_limited_route():
     return api
 
 
-@pytest.mark.parametrize("entry", ["not-an-ip", "10.0.0.0/nine", "10.0.0.0/33", "::1/129"])
-def test_an_invalid_entry_fails_at_registration(entry):
+@pytest.mark.parametrize("entry", ["not-an-ip", "10.0.0.0/nine", "10.0.0.0/33", "::1/129", 10, None])
+def test_an_invalid_entry_fails_at_startup(entry):
     """A typo stops startup instead of quietly widening a bucket."""
     with (
         override_settings(BOLT_TRUSTED_PROXIES=["10.0.0.0/8", entry]),
         pytest.raises(ImproperlyConfigured, match="BOLT_TRUSTED_PROXIES"),
     ):
-        _api_with_limited_route()
+        TestClient(_api_with_limited_route())
 
 
 @pytest.mark.parametrize(
@@ -54,29 +55,32 @@ def test_an_invalid_entry_fails_at_registration(entry):
         pytest.param(True, id="boolean"),
     ],
 )
-def test_a_setting_that_is_not_a_list_fails_at_registration(configured):
+def test_a_setting_that_is_not_a_list_fails_at_startup(configured):
     """Reject the whole setting by type, before anything iterates it."""
     with (
         override_settings(BOLT_TRUSTED_PROXIES=configured),
         pytest.raises(ImproperlyConfigured, match="must be a list"),
     ):
-        _api_with_limited_route()
+        TestClient(_api_with_limited_route())
 
 
 @pytest.mark.parametrize("configured", [None, [], (), ["10.0.0.1"], ["10.0.0.0/8", "::1"], ("10.0.0.0/8",)])
-def test_a_valid_setting_registers(configured):
+def test_a_valid_setting_starts(configured):
     """Addresses and blocks are both accepted, in either family, list or tuple."""
-    with override_settings(BOLT_TRUSTED_PROXIES=configured):
-        assert _api_with_limited_route() is not None
+    with override_settings(BOLT_TRUSTED_PROXIES=configured), TestClient(_api_with_limited_route()):
+        pass
 
 
-def test_a_route_without_a_rate_limit_is_unaffected():
-    """Only a rate limited route reads the list, so only it should validate one."""
-    with override_settings(BOLT_TRUSTED_PROXIES=["not-an-ip"]):
+def test_an_invalid_deployment_setting_fails_even_without_a_limited_route():
+    """The deployment-wide policy is validated independently of route shape."""
+    with (
+        override_settings(BOLT_TRUSTED_PROXIES=["not-an-ip"]),
+        pytest.raises(ImproperlyConfigured, match="BOLT_TRUSTED_PROXIES"),
+    ):
         api = BoltAPI()
 
         @api.get("/plain")
         async def plain():
             return {"ok": True}
 
-        assert api is not None
+        TestClient(api)

--- a/python/tests/test_rate_limit_client_ip.py
+++ b/python/tests/test_rate_limit_client_ip.py
@@ -84,3 +84,20 @@ def test_an_invalid_deployment_setting_fails_even_without_a_limited_route():
             return {"ok": True}
 
         TestClient(api)
+
+
+def test_the_ip_key_is_matched_without_regard_to_case():
+    """`key="IP"` must key on the address, not on a header named `ip`."""
+    api = BoltAPI()
+
+    @api.get("/limited")
+    @rate_limit(rps=1, burst=2, key="IP")
+    async def limited():
+        return {"ok": True}
+
+    with TestClient(api) as client:
+        for _ in range(3):
+            status = client.get("/limited", headers={"ip": "a"}).status_code
+        assert status == 429
+        # A header named `ip` must not buy a new bucket.
+        assert client.get("/limited", headers={"ip": "b"}).status_code == 429

--- a/python/tests/test_rate_limit_client_ip.py
+++ b/python/tests/test_rate_limit_client_ip.py
@@ -39,14 +39,23 @@ def test_an_invalid_entry_fails_at_registration(entry):
         _api_with_limited_route()
 
 
-@pytest.mark.parametrize("configured", ["10.0.0.0/8", ""])
-def test_a_string_setting_fails_at_registration(configured):
-    """
-    A bare string iterates one character at a time, so reject it by name.
-
-    The empty string counts. It is falsey, so a normalize-then-check order would
-    read it as an empty list and report no proxies at all.
-    """
+@pytest.mark.parametrize(
+    "configured",
+    [
+        pytest.param("10.0.0.0/8", id="string"),
+        # Falsey, so a normalize-then-check order reads it as an empty list and
+        # reports no proxies at all.
+        pytest.param("", id="empty-string"),
+        # Iterates its keys, which would look like a valid list of proxies.
+        pytest.param({"10.0.0.0/8": "edge proxy"}, id="mapping"),
+        pytest.param({}, id="empty-mapping"),
+        # Not iterable, so the loop would raise a bare TypeError.
+        pytest.param(42, id="integer"),
+        pytest.param(True, id="boolean"),
+    ],
+)
+def test_a_setting_that_is_not_a_list_fails_at_registration(configured):
+    """Reject the whole setting by type, before anything iterates it."""
     with (
         override_settings(BOLT_TRUSTED_PROXIES=configured),
         pytest.raises(ImproperlyConfigured, match="must be a list"),
@@ -54,9 +63,9 @@ def test_a_string_setting_fails_at_registration(configured):
         _api_with_limited_route()
 
 
-@pytest.mark.parametrize("configured", [None, [], ["10.0.0.1"], ["10.0.0.0/8", "::1"]])
+@pytest.mark.parametrize("configured", [None, [], (), ["10.0.0.1"], ["10.0.0.0/8", "::1"], ("10.0.0.0/8",)])
 def test_a_valid_setting_registers(configured):
-    """Addresses and blocks are both accepted, in either family."""
+    """Addresses and blocks are both accepted, in either family, list or tuple."""
     with override_settings(BOLT_TRUSTED_PROXIES=configured):
         assert _api_with_limited_route() is not None
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -877,10 +877,15 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
         None
     };
 
-    // Get peer address only when needed (rate limiting or conn_remote_addr fallback).
-    // Skip ip().to_string() for simple API routes with no auth/middleware/rate-limiting.
-    let peer_addr = if has_route_rate_limit || must_extract_headers {
-        req.peer_addr().map(|addr| addr.ip().to_string())
+    // Routes that do not extract headers skip client-address work entirely.
+    // Routes that do need connection metadata and IP rate limiting share this
+    // one canonical result. With no trusted proxy this is one `peer_addr()`.
+    let client_ip = if must_extract_headers {
+        middleware::client_ip::resolve_from_headers(
+            req.headers(),
+            req.peer_addr().map(|address| address.ip()),
+            &state.trusted_proxies,
+        )
     } else {
         None
     };
@@ -892,7 +897,7 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
                 if let Some(response) = middleware::rate_limit::check_rate_limit(
                     handler_id,
                     headers_map,
-                    peer_addr.as_deref(),
+                    client_ip.as_ref(),
                     rate_config,
                     &method,
                     &path,
@@ -974,18 +979,10 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
             .and_then(|h| h.get("x-forwarded-proto"))
             .cloned()
             .unwrap_or_else(|| "http".to_string());
-        // X-Forwarded-For: leftmost IP is the original client (RFC 7239 §7.1)
-        let remote_addr = headers
-            .as_ref()
-            .and_then(|h| h.get("x-forwarded-for"))
-            .and_then(|v| v.split(',').next().map(|s| s.trim().to_string()))
-            .or_else(|| headers.as_ref().and_then(|h| h.get("x-real-ip").cloned()))
-            .or_else(|| peer_addr.clone())
-            .unwrap_or_else(|| "127.0.0.1".to_string());
-        (host, scheme, remote_addr)
+        (host, scheme, client_ip)
     } else {
         // No META needed → empty strings (META getter will return defaults)
-        (String::new(), String::new(), String::new())
+        (String::new(), String::new(), None)
     };
 
     // Determine if form parsing is needed and get content type

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use crate::handler::handle_request;
 use bolt_asgi::asgi_mounts::validate_and_sort_asgi_mounts;
 use bolt_core::metadata::{CompressionConfig, CorsConfig, RouteMetadata, RouteMetadataStore};
+use bolt_core::middleware::client_ip::TrustedProxies;
 use bolt_core::middleware::compression::CompressionMiddleware;
 use bolt_core::middleware::cors::CorsMiddleware;
 use bolt_core::router::Router;
@@ -250,6 +251,10 @@ pub fn start_server(
             "Routes not registered",
         ));
     }
+
+    // Parse deployment proxy trust once. Python validation preserves Django's
+    // ImproperlyConfigured error for malformed settings.
+    let trusted_proxies = Arc::new(TrustedProxies::from_django_settings(py)?);
 
     // Configure tokio runtime with adequate blocking thread pool for concurrent streaming
     // Default is 512, but with concurrent SSE clients doing blocking operations (time.sleep),
@@ -799,6 +804,7 @@ pub fn start_server(
         global_cors_config,
         cors_origin_regexes,
         global_compression_config: global_compression_config.clone(),
+        trusted_proxies,
         router: None,                        // Production uses GLOBAL_ROUTER
         route_metadata: None,                // Production uses ROUTE_METADATA
         asgi_mounts: None,                   // Production uses GLOBAL_ASGI_MOUNTS

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -31,7 +31,8 @@ use bolt_asgi::asgi_mounts::validate_and_sort_asgi_mounts;
 use bolt_core::form_parsing::{
     parse_multipart, parse_urlencoded, FormParseResult, DEFAULT_MAX_PARTS, DEFAULT_MEMORY_LIMIT,
 };
-use bolt_core::metadata::{CorsConfig, RouteMetadata, RouteMetadataStore};
+use bolt_core::metadata::{CorsConfig, RateLimitKey, RouteMetadata, RouteMetadataStore};
+use bolt_core::middleware::client_ip::TrustedProxies;
 use bolt_core::middleware::compression::CompressionMiddleware;
 use bolt_core::middleware::cors::CorsMiddleware;
 use bolt_core::router::Router;
@@ -121,6 +122,7 @@ pub struct TestAppState {
     /// Global compression config (mirrors production server). Drives the
     /// streaming-compression codec selection in `handler.rs`.
     pub global_compression_config: Option<Arc<bolt_core::metadata::CompressionConfig>>,
+    pub trusted_proxies: Arc<TrustedProxies>,
     pub debug: bool,
     pub max_payload_size: usize,
     /// Max byte length for parameter values (resolved once from
@@ -249,6 +251,8 @@ pub fn create_test_app(
     static_files_config: Option<&Bound<'_, PyDict>>,
     compression_config: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<u64> {
+    let trusted_proxies = Arc::new(TrustedProxies::from_django_settings(py)?);
+
     let global_cors_config = if let Some(cors_dict) = cors_config {
         Some(parse_cors_config_from_dict(cors_dict)?)
     } else {
@@ -340,6 +344,7 @@ pub fn create_test_app(
         dispatch: dispatch.clone_ref(py),
         global_cors_config,
         global_compression_config,
+        trusted_proxies,
         debug,
         max_payload_size,
         max_param_length: bolt_core::type_coercion::resolve_max_param_length(),
@@ -538,6 +543,7 @@ pub fn test_request(
                 dispatch,
                 global_cors_config,
                 global_compression_config,
+                trusted_proxies,
                 debug,
                 max_payload_size,
                 max_param_length,
@@ -554,6 +560,7 @@ pub fn test_request(
                     Python::attach(|py| state.dispatch.clone_ref(py)),
                     state.global_cors_config.clone(),
                     state.global_compression_config.clone(),
+                    state.trusted_proxies.clone(),
                     state.debug,
                     state.max_payload_size,
                     state.max_param_length,
@@ -575,6 +582,7 @@ pub fn test_request(
                 global_cors_config: global_cors_config.clone(),
                 cors_origin_regexes: vec![],
                 global_compression_config,
+                trusted_proxies,
                 router: Some(router.clone()),
                 route_metadata: Some(route_metadata.clone()),
                 asgi_mounts: Some(asgi_mounts.clone()),
@@ -870,16 +878,18 @@ async fn handle_test_request_internal(
         Err(response) => return response,
     };
 
-    let peer_addr = req.peer_addr().map(|addr| addr.ip().to_string());
+    let client_ip = bolt_core::middleware::client_ip::resolve_from_headers(
+        req.headers(),
+        req.peer_addr().map(|address| address.ip()),
+        &state.trusted_proxies,
+    );
 
-    // Get connection info from Actix - handles proxies, IPv6, etc. correctly
+    // Host and scheme retain Actix behavior; REMOTE_ADDR uses Bolt's explicit
+    // forwarding-header trust policy.
     let conn_info = req.connection_info();
     let conn_host = conn_info.host().to_owned();
     let conn_scheme = conn_info.scheme().to_owned();
-    let conn_remote_addr = conn_info
-        .realip_remote_addr()
-        .unwrap_or("127.0.0.1")
-        .to_owned();
+    let conn_remote_addr = client_ip;
 
     // Rate limiting
     if let Some(ref meta) = route_meta {
@@ -887,7 +897,7 @@ async fn handle_test_request_internal(
             if let Some(response) = middleware::rate_limit::check_rate_limit(
                 handler_id,
                 &headers,
-                peer_addr.as_deref(),
+                client_ip.as_ref(),
                 rate_config,
                 method,
                 path,
@@ -1205,7 +1215,7 @@ async fn handle_test_request_internal(
             meta_cache: std::sync::OnceLock::new(),
             conn_host: conn_host.clone(),
             conn_scheme: conn_scheme.clone(),
-            conn_remote_addr: conn_remote_addr.clone(),
+            conn_remote_addr,
         };
         let request_obj = Py::new(py, request)?;
 
@@ -1320,14 +1330,28 @@ pub fn handle_test_websocket(
 
     let handler_id = route.handler_id;
     let handler = route.handler.clone_ref(py);
-
     // Rate limiting for WebSocket
     if let Some(route_meta) = app.route_metadata.get(handler_id) {
         if let Some(ref rate_config) = route_meta.rate_limit_config {
+            let client_ip = (rate_config.key == RateLimitKey::Ip)
+                .then(|| {
+                    bolt_core::middleware::client_ip::resolve(
+                        header_map
+                            .get("x-forwarded-for")
+                            .into_iter()
+                            .map(|value| Some(value.as_str())),
+                        header_map
+                            .get("x-real-ip")
+                            .map(|value| Some(value.as_str())),
+                        Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+                        &app.trusted_proxies,
+                    )
+                })
+                .flatten();
             if bolt_core::middleware::rate_limit::check_rate_limit(
                 handler_id,
                 &header_map,
-                Some("127.0.0.1"),
+                client_ip.as_ref(),
                 rate_config,
                 "GET",
                 &path,


### PR DESCRIPTION
Fixes #302

`@rate_limit(key="ip")` took the leftmost entry of `X-Forwarded-For` as the client address. That entry is whatever the client sent — a proxy appends to the header rather than replacing it, so the leftmost value is the least trustworthy part of the chain. Behind an appending proxy (what Caddy does as soon as `trusted_proxies` is set, and what most setups do), or with Bolt exposed directly, one header gave you a fresh bucket on every request. Nothing looks wrong from the outside, which is why I only found it reading the source.

What this does:

- Keys on the connection peer address by default, and ignores forwarding headers entirely.
- Adds `BOLT_TRUSTED_PROXIES`, a list of addresses or CIDR blocks. When the peer is in that list, Bolt reads `X-Forwarded-For` from the right and takes the first entry that is not a listed proxy. It falls back to `X-Real-IP`, then `Remote-Addr`, then the peer.
- Validates the setting in Python with `ipaddress`, and again when Rust parses it, so a typo fails at startup instead of quietly widening a bucket.

That is the same shape as Django's `SECURE_PROXY_SSL_HEADER`, Caddy's `trusted_proxies` and nginx's `set_real_ip_from`: nothing declared means nothing trusted.

**This changes behaviour for anyone already running behind a proxy.** Without the setting their callers now share one bucket, which is why the CHANGELOG entry says to add it. I could not find a way to get a safe default without that, since Bolt cannot tell an appending proxy from a client.

The resolution rules live in a new `crates/bolt-core/src/middleware/client_ip.rs`, together with the CIDR matching. No new dependency — `std::net` plus a prefix compare, and it folds `::ffff:a.b.c.d` back to IPv4 so a dual-stack listener does not split one client across two buckets. The list rides on route metadata as a top-level key rather than inside the `rate_limit` middleware dict, because proxies are a property of the deployment and not of one route; `RateLimitConfig` carries the already-parsed blocks, so nothing is parsed per request.

Two things I left alone on purpose, both out of scope for a rate-limiting fix, happy to follow up on either:

- `src/handler.rs:978` builds Django's `REMOTE_ADDR` from the leftmost `X-Forwarded-For` the same way. That is request data user code can read, not just a limit key.
- `python/django_bolt/logging/middleware.py:125` does the same for the `client_ip` log field. `test_logging.py:321` pins that behaviour.

## How was this tested?

- [x] `just lint-lib` and `just test-py` pass — 2624 passed, 7 skipped
- [x] Rust changed: `just build` succeeds, `cargo test -p bolt-core` is 157 passed
- [ ] No new feature to exercise in the example project

`cargo fmt --check` is clean and `cargo clippy --workspace --all-targets` reports nothing in the lines this touches.

15 unit tests in `client_ip.rs` cover the resolution rules and the CIDR matching. On the Python side the split follows the testing guide: anything needing a real client address is a `server_integration` test, because `TestRequest` leaves `peer_addr` unset and every in-process caller therefore resolves to the same constant. So `python/tests/integration/test_rate_limit_client_ip_server_integration.py` runs the header behaviour against a real `runbolt` over TCP (two servers, since the setting is read once per process), and `python/tests/test_rate_limit_client_ip.py` keeps the configuration checks in process. Red-green: 12 of the 19 fail against master, including both real-server ones. The 7 that pass there are the cases master already satisfies by trusting the header unconditionally, plus the valid-configuration ones.

## Performance consideration

The request path keeps the same shape. For anyone who does not set `BOLT_TRUSTED_PROXIES` it is one `is_empty()` check, one `IpAddr` parse of the peer, and the same `to_string` the old code already did — the header lookups are skipped entirely, where before there were up to three. With the setting, the peer is compared against a small `Vec<IpCidr>` of already-parsed blocks, and `X-Forwarded-For` is walked once. Everything is parsed at registration, nothing per request, and no allocation was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

Yes. The PR touches the HTTP and WebSocket request paths.

The hot path now:

- Reads the peer IP.
- Resolves the client IP only when `RateLimitKey::Ip` is configured.
- Checks trusted proxy CIDR entries.
- Parses forwarding headers when the peer is trusted.
- Passes the resolved IP to rate limiting.
- Reuses the resolved IP for `REMOTE_ADDR` and request logging.

The implementation avoids the main expensive operations:

- Trusted proxy configuration is parsed once at startup.
- Parsed proxy data is stored in `AppState`.
- The client IP is resolved once per request and reused.
- The implementation avoids per-request configuration parsing.
- The implementation avoids unnecessary string allocation for IP-based rate-limit keys.

The required per-request work is appropriate for the feature. The main additional cost is header parsing and trusted-proxy matching for IP-keyed rate limits. Requests that use header-based rate limits do not need client-IP resolution.

No clearly wasteful hot-path work is described in the changes. The design moves configuration work out of the hot path and centralizes the required client-IP resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->