### PR TITLE
fix(rate-limit)!: reject key="user" and key="api_key"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`@rate_limit(key="user")` and `key="api_key"` raise** - Neither was implemented. The limit runs before authentication, so no identity is available. Both fell into the header catch-all, matched no header, and resolved to one shared bucket, thus a route marked "per user" was a single global limit that one caller could exhaust for everyone. Both keys now raise `ImproperlyConfigured` at import time. Use `key="ip"` or a request header name. (#301)
+
 ### Fixed
 
 - **bolt-mcp 0.2.2: `resultType` on Python-built results** - `tools/call`, `resources/read` and `prompts/get` results now carry `resultType: "complete"` for 2026-07-28 clients. Claude Code and claude.ai connectors rejected every tool call without it. Legacy peers keep the old wire shape.

--- a/docs/src/topics/middleware.md
+++ b/docs/src/topics/middleware.md
@@ -72,6 +72,26 @@ Parameters:
 
 - `rps` - Requests per second allowed
 - `burst` - Maximum burst size (allows short spikes)
+- `key` - What to count per: `"ip"` (the default) or a request header name
+
+### Counting per caller
+
+`key="ip"` counts per client address. A header name counts per header value:
+
+```python
+@api.get("/api/data")
+@rate_limit(rps=10, key="x-api-key")
+async def data():
+    return {"data": []}
+```
+
+Callers that do not send the header share one bucket.
+
+!!! warning "`key="user"` and `key="api_key"` are rejected"
+    Both were documented but never implemented. The limit runs before
+    authentication, so no identity exists to count per. Bolt raises
+    `ImproperlyConfigured` at import time. Use `key="ip"` or a header that
+    carries the identity.
 
 ### How it works
 

--- a/python/django_bolt/middleware/middleware.py
+++ b/python/django_bolt/middleware/middleware.py
@@ -32,6 +32,8 @@ from typing import (
     runtime_checkable,
 )
 
+from django.core.exceptions import ImproperlyConfigured
+
 from ..exceptions import HTTPException
 
 if TYPE_CHECKING:
@@ -391,6 +393,13 @@ def middleware(*args, **kwargs):
     return decorator
 
 
+# Keys that name an authenticated identity. Rust runs the rate limit check
+# before it validates auth, so no identity exists at that point. Rust has no arm
+# for these, and the catch-all looks for a request header with the same name.
+# That header never arrives, so every caller shares the bucket for "unknown".
+_UNIMPLEMENTED_RATE_LIMIT_KEYS = ("user", "api_key")
+
+
 def rate_limit(rps: int = 100, burst: int | None = None, key: str = "ip"):
     """
     Rate limiting decorator (Rust-accelerated).
@@ -401,7 +410,12 @@ def rate_limit(rps: int = 100, burst: int | None = None, key: str = "ip"):
     Args:
         rps: Requests per second limit
         burst: Burst capacity (defaults to 2x rps)
-        key: Rate limit key strategy ("ip", "user", "api_key", or header name)
+        key: What to count per. Use "ip" for the client address, or a request
+            header name such as "x-api-key" to count per header value.
+
+    Raises:
+        ImproperlyConfigured: `key` is "user" or "api_key". Neither is
+            implemented, and both used to collapse into one shared bucket.
 
     Example:
         @api.get("/api/data")
@@ -409,6 +423,15 @@ def rate_limit(rps: int = 100, burst: int | None = None, key: str = "ip"):
         async def get_data(request: Request) -> dict:
             return {"data": [...]}
     """
+    if key in _UNIMPLEMENTED_RATE_LIMIT_KEYS:
+        raise ImproperlyConfigured(
+            f"@rate_limit(key={key!r}) is not implemented. The limit runs before "
+            f"authentication, so no identity is available to key on. Every caller "
+            f"shared one bucket, which made the route easier to exhaust than an "
+            f"unlimited one. Use key='ip', or a request header that carries the "
+            f"identity, such as key='x-api-key'. See "
+            f"https://github.com/dj-bolt/django-bolt/issues/301."
+        )
 
     def decorator(func):
         if not hasattr(func, "__bolt_middleware__"):

--- a/python/tests/test_rate_limit_keys.py
+++ b/python/tests/test_rate_limit_keys.py
@@ -1,0 +1,56 @@
+"""
+Tests for which `@rate_limit(key=...)` values Bolt accepts.
+
+`key="user"` and `key="api_key"` were documented but never implemented. Rust
+checks the limit before it validates auth, so no identity exists at that point.
+Both keys fell into the header catch-all, found no header with that name, and
+resolved to the constant `"unknown"`. Every caller then shared one bucket, so a
+route marked "1 rps per user" was really "1 rps in total".
+"""
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from django_bolt import BoltAPI
+from django_bolt.middleware import rate_limit
+from django_bolt.testing import TestClient
+
+
+@pytest.mark.parametrize("key", ["user", "api_key"])
+def test_an_identity_key_is_rejected(key):
+    """Fail at decoration instead of collapsing into one shared bucket."""
+    with pytest.raises(ImproperlyConfigured, match="is not implemented"):
+        rate_limit(rps=10, key=key)
+
+
+@pytest.mark.parametrize("key", ["user", "api_key"])
+def test_the_error_names_a_working_alternative(key):
+    """A caller has to be able to act on the message."""
+    with pytest.raises(ImproperlyConfigured, match="x-api-key"):
+        rate_limit(rps=10, key=key)
+
+
+def test_the_default_key_still_works():
+    api = BoltAPI()
+
+    @api.get("/default-key")
+    @rate_limit(rps=100, burst=100)
+    async def handler():
+        return {"ok": True}
+
+    with TestClient(api) as client:
+        assert client.get("/default-key").status_code == 200
+
+
+def test_a_header_key_still_works():
+    """The header arm is the one that always segmented correctly."""
+    api = BoltAPI()
+
+    @api.get("/header-key")
+    @rate_limit(rps=100, burst=100, key="x-api-key")
+    async def handler():
+        return {"ok": True}
+
+    with TestClient(api) as client:
+        response = client.get("/header-key", headers={"x-api-key": "caller-one"})
+        assert response.status_code == 200


### PR DESCRIPTION
Refs #301

`@rate_limit` documents `key` as `"ip"`, `"user"`, `"api_key"` or a header name. `check_rate_limit` implements two of those. `"user"` and `"api_key"` fall into the header catch-all, look for a request header named literally `user` / `api_key`, miss, and resolve to the constant `"unknown"` — so every caller shares the bucket at `(handler_id, "unknown")`.

That inverts the intent: a route annotated "1 rps per user" is "1 rps in total", and one caller can lock every other authenticated user out of it. There is no warning at startup and no way to see it from a response.

Repro on 0.10.2, one route at `rps=1, burst=5`, ten requests:

```
key="<header name>", 10 requests w/ 10 distinct values -> 200 x10
key="ip",            10 requests                       -> 200 x5, 429 x5
key="user",          10 requests as 10 distinct JWTs   -> 200 x5, 429 x5   <- bug
```

The header case shows the key machinery itself is fine.

A real `key="user"` needs the check to run after `validate_auth_and_guards` — today it runs before, so there is no identity yet — plus a decision about what limits an unauthenticated request on an identity-keyed route. That is a design call, so this PR does not attempt it.

What it does is remove the silent part. Both keys raise `ImproperlyConfigured` at import time, with a message naming the two options that work. That matches the rule already applied to auth metadata in `server.rs`: "Failures abort startup: continuing would serve the route without its configured auth/middleware, which is a silent security downgrade." Same class of problem.

If you would rather not break existing code at import, a one-time warning per handler is a one-line swap and I will change it. Worth weighing against the fact that the code it breaks is already not doing what it says.

While in there: an unmatched key resolving to a shared `"unknown"` bucket is the general case, so a route keyed on a header that some clients omit lumps all of those clients together too. And `MAX_KEY_LENGTH` returns 400 when the keyed header is over 256 bytes, which `key="authorization"` with a JWT hits easily. Hashing the key rather than using it raw would fix both. I left that out to keep this small.

## How was this tested?

- [x] `just lint-lib` and `just test-py` pass — 2610 passed, 7 skipped, 0 failed
- [ ] No Rust change
- [ ] No new feature

6 tests in `python/tests/test_rate_limit_keys.py`. Nothing in the repo used either key.

## Performance consideration

Import time only. Nothing on the request path changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

The PR touches rate-limit configuration code, but it does not add work to the per-request hot path.

`rate_limit` now validates `key="user"` and `key="api_key"` when the decorator is applied. Invalid configurations raise `ImproperlyConfigured` at import time.

For valid keys, request-time rate-limit behavior remains unchanged. The added validation is required to reject unsupported options before they create a shared `"unknown"` bucket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->