### PR TITLE
bolt-mcp: loopback code delivery interstitial page

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -430,7 +430,13 @@ jobs:
           # RUSTSEC-2023-0071 (rsa Marvin attack): no fixed release exists. rsa is
           # transitive via jsonwebtoken, and the timing oracle targets RSA
           # private-key decryption, not the public-key path JWT verification uses.
-          cargo audit --ignore RUSTSEC-2023-0071
+          #
+          # RUSTSEC-2026-0258 (h2 unbounded empty DATA frames): the patch is in
+          # h2 0.4.16, but the 0.3 line has no backport. h2 is transitive via
+          # actix-http, which needs h2 0.3, so actix-web 4.x cannot reach the
+          # patched release. Low severity, and it needs HTTP/2. Remove this
+          # ignore when actix-web moves to h2 0.4.
+          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0258
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -427,16 +427,12 @@ jobs:
       - name: cargo audit (Rust deps in Cargo.lock)
         run: |
           cargo install cargo-audit --locked
-          # RUSTSEC-2023-0071 (rsa Marvin attack): no fixed release exists. rsa is
-          # transitive via jsonwebtoken, and the timing oracle targets RSA
-          # private-key decryption, not the public-key path JWT verification uses.
-          #
           # RUSTSEC-2026-0258 (h2 unbounded empty DATA frames): the patch is in
           # h2 0.4.16, but the 0.3 line has no backport. h2 is transitive via
           # actix-http, which needs h2 0.3, so actix-web 4.x cannot reach the
           # patched release. Low severity, and it needs HTTP/2. Remove this
           # ignore when actix-web moves to h2 0.4.
-          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0258
+          cargo audit --ignore RUSTSEC-2026-0258
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **bolt-mcp: loopback code delivery** - After consent, loopback redirect URIs (`http://localhost` / `127.0.0.1` / `[::1]`) get an interstitial page on the issuer origin instead of a raw 302. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` redirect, so the client never received the code. The page navigates with JS, keeps a click-through link, and shows the code for copy-paste. `https` redirect URIs keep the plain 302. Override the new `AuthorizationServer.code_redirect_response(redirect_url)` to customize the post-consent response. (#307)
+- **bolt-mcp: loopback code delivery** - After consent, a loopback redirect URI (`http://localhost` / `127.0.0.1` / `[::1]`) receives an interstitial page on the issuer origin. Before, it received a raw 302. Some browsers block the `https → http://localhost` redirect. Firefox with HTTPS-Only mode is one example. The client then never received the code. The page navigates with JavaScript, keeps a click-through link, and shows the code for copy-paste. An `https` redirect URI keeps the plain 302. To change the post-consent response, override the new `AuthorizationServer.code_redirect_response(redirect_url)`. (#307)
 - **bolt-mcp 0.2.2: `resultType` on Python-built results** - `tools/call`, `resources/read` and `prompts/get` results now carry `resultType: "complete"` for 2026-07-28 clients. Claude Code and claude.ai connectors rejected every tool call without it. Legacy peers keep the old wire shape.
 
 ## [0.10.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **bolt-mcp: loopback code delivery** - After consent, loopback redirect URIs (`http://localhost` / `127.0.0.1` / `[::1]`) get an interstitial page on the issuer origin instead of a raw 302. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` redirect, so the client never received the code. The page navigates with JS, keeps a click-through link, and shows the code for copy-paste. `https` redirect URIs keep the plain 302. Override the new `AuthorizationServer.code_redirect_response(redirect_url)` to customize the post-consent response. (#307)
 - **bolt-mcp 0.2.2: `resultType` on Python-built results** - `tools/call`, `resources/read` and `prompts/get` results now carry `resultType: "complete"` for 2026-07-28 clients. Claude Code and claude.ai connectors rejected every tool call without it. Legacy peers keep the old wire shape.
 
 ## [0.10.2]

--- a/docs/src/topics/mcp.md
+++ b/docs/src/topics/mcp.md
@@ -429,7 +429,7 @@ For trivial cases set attributes inline instead of subclassing: `AuthorizationSe
 | `redirect_uri_allowed(registered, redirect_uri)` | `/authorize` | change redirect-URI matching |
 | `code_redirect_response(redirect_url)` | consent approved | change how the code reaches the client |
 
-**Loopback clients.** After consent, an `https` redirect URI gets a plain 302. A loopback redirect URI (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) gets an interstitial page instead. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` 302, so "Allow" appears to do nothing. The interstitial navigates with JS, keeps a click-through link, and shows the code for copy-paste. Override `code_redirect_response(redirect_url)` to change this — for example, return `Redirect(redirect_url, status_code=302)` to force the raw 302.
+**Loopback clients.** After consent, an `https` redirect URI gets a plain 302. A loopback redirect URI (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) gets an interstitial page instead. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` 302, so "Allow" appears to do nothing. The interstitial navigates with JS, keeps a click-through link, and shows the code for copy-paste. Override `code_redirect_response(redirect_url)` to change this — for example, return `Redirect(redirect_url, status_code=302)` (from `django_bolt.responses`) to force the raw 302.
 
 #### Endpoints
 

--- a/docs/src/topics/mcp.md
+++ b/docs/src/topics/mcp.md
@@ -429,7 +429,7 @@ For trivial cases set attributes inline instead of subclassing: `AuthorizationSe
 | `redirect_uri_allowed(registered, redirect_uri)` | `/authorize` | change redirect-URI matching |
 | `code_redirect_response(redirect_url)` | consent approved | change how the code reaches the client |
 
-**Loopback clients.** After consent, an `https` redirect URI gets a plain 302. A loopback redirect URI (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) gets an interstitial page instead. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` 302, so "Allow" appears to do nothing. The interstitial navigates with JS, keeps a click-through link, and shows the code for copy-paste. Override `code_redirect_response(redirect_url)` to change this — for example, return `Redirect(redirect_url, status_code=302)` (from `django_bolt.responses`) to force the raw 302.
+**Loopback clients.** After consent, an `https` redirect URI receives a plain 302. A loopback redirect URI (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) receives an interstitial page. Some browsers block the `https → http://localhost` redirect. Firefox with HTTPS-Only mode is one example. Then the "Allow" button seems to do nothing. The interstitial page prevents this. It navigates with JavaScript, keeps a click-through link, and shows the code for copy-paste. To force the raw 302, override `code_redirect_response(redirect_url)`. Return `Redirect(redirect_url, status_code=302)` from `django_bolt.responses`.
 
 #### Endpoints
 

--- a/docs/src/topics/mcp.md
+++ b/docs/src/topics/mcp.md
@@ -427,6 +427,9 @@ For trivial cases set attributes inline instead of subclassing: `AuthorizationSe
 | `render_login(params, *, error=None)` | no session | custom sign-in HTML |
 | `render_consent(params, *, client_name, username)` | signed in | custom consent HTML |
 | `redirect_uri_allowed(registered, redirect_uri)` | `/authorize` | change redirect-URI matching |
+| `code_redirect_response(redirect_url)` | consent approved | change how the code reaches the client |
+
+**Loopback clients.** After consent, an `https` redirect URI gets a plain 302. A loopback redirect URI (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) gets an interstitial page instead. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` 302, so "Allow" appears to do nothing. The interstitial navigates with JS, keeps a click-through link, and shows the code for copy-paste. Override `code_redirect_response(redirect_url)` to change this — for example, return `Redirect(redirect_url, status_code=302)` to force the raw 302.
 
 #### Endpoints
 

--- a/python/bolt-mcp/src/bolt_mcp/oauth/config.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/config.py
@@ -59,7 +59,7 @@ class AuthorizationServer:
 
     Behavior — override these methods in a subclass to customize:
         get_extra_claims, authenticate, resolve_user, load_user, render_login,
-        render_consent, redirect_uri_allowed.
+        render_consent, redirect_uri_allowed, code_redirect_response.
     """
 
     # ── configuration (override via subclass attributes or constructor kwargs) ──
@@ -154,3 +154,23 @@ class AuthorizationServer:
         """Whether ``redirect_uri`` is permitted. Default: exact match against registered
         values (no open redirect). Override only with great care."""
         return redirect_uri in (registered or [])
+
+    def code_redirect_response(self, redirect_url: str) -> Any:
+        """Build the post-consent response that delivers the authorization code.
+
+        ``redirect_url`` is the validated client redirect URI with ``code``,
+        ``iss`` and ``state`` already appended. Default: a plain 302, except for
+        loopback redirect URIs (``http://localhost`` / ``127.0.0.1`` / ``[::1]``),
+        which get an interstitial page on the issuer origin — browsers can block
+        a ``https → http://localhost`` 302 (Firefox HTTPS-Only mode). Override to
+        customize how the code reaches the client.
+        """
+        from django_bolt.responses import HTML, Redirect  # noqa: PLC0415
+
+        from . import consent  # noqa: PLC0415
+
+        if consent.is_loopback_uri(redirect_url):
+            # The page carries a live code: never cache it, never leak a referrer.
+            headers = {"Cache-Control": "no-store", "Pragma": "no-cache", "Referrer-Policy": "no-referrer"}
+            return HTML(consent.code_delivery_page(redirect_url), headers=headers)
+        return Redirect(redirect_url, status_code=302)

--- a/python/bolt-mcp/src/bolt_mcp/oauth/consent.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/consent.py
@@ -104,7 +104,10 @@ def consent_page(
 
 def is_loopback_uri(uri: str) -> bool:
     """Tell if ``uri`` is an RFC 8252 loopback redirect URI (plain-http localhost)."""
-    parts = urlsplit(uri)
+    try:
+        parts = urlsplit(uri)
+    except ValueError:
+        return False
     return parts.scheme == "http" and parts.hostname in ("localhost", "127.0.0.1", "::1")
 
 
@@ -116,7 +119,10 @@ def code_delivery_page(redirect_url: str) -> str:
     keeps a click-through link (a user gesture succeeds in more configurations),
     and shows the code for copy-paste as a last resort.
     """
-    code = parse_qs(urlsplit(redirect_url).query).get("code", [""])[0]
+    # The registered redirect URI may already contain query parameters, including
+    # a parameter named ``code``. The authorization response is appended last, so
+    # display the last value rather than a client-controlled earlier value.
+    code = parse_qs(urlsplit(redirect_url).query).get("code", [""])[-1]
     # A JSON string literal is a valid JS string literal; escape "<" so the
     # URL can never close the <script> block.
     js_url = json.dumps(redirect_url).replace("<", "\\u003c")
@@ -125,5 +131,5 @@ def code_delivery_page(redirect_url: str) -> str:
 <a class="btn" href="{escape(redirect_url)}" rel="noreferrer">Click here if you are not redirected</a>
 <p style="margin:16px 0 0">If the application does not open, paste this code into it:</p>
 <div class="code">{escape(code)}</div>
-<script>location.replace({js_url});</script>"""
+<script>location.assign({js_url});</script>"""
     return _PAGE.format(title="Authorization complete", body=body)

--- a/python/bolt-mcp/src/bolt_mcp/oauth/consent.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/consent.py
@@ -7,8 +7,10 @@ without server-side state. All interpolated values are HTML-escaped.
 
 from __future__ import annotations
 
+import json
 from html import escape
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 from .config import AuthorizationServer
 
@@ -43,6 +45,10 @@ _PAGE = """<!doctype html>
    font-size:12px;margin-bottom:14px}}
  .scope{{display:inline-block;background:#1d2128;border:1px solid #2c313c;border-radius:6px;
    padding:2px 8px;margin:3px 4px 0 0;font-size:12px;color:#cfd4dd}}
+ a.btn{{display:block;text-align:center;padding:10px 14px;border-radius:9px;background:#4f7cff;
+   color:#fff;font-size:14px;font-weight:600;text-decoration:none}}
+ .code{{background:#0f1115;border:1px solid #2c313c;border-radius:9px;padding:10px 12px;margin-top:6px;
+   font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;word-break:break-all}}
 </style></head><body><div class="card">{body}</div></body></html>"""
 
 
@@ -94,3 +100,30 @@ def consent_page(
   </div>
 </form>"""
     return _PAGE.format(title="Authorize", body=body)
+
+
+def is_loopback_uri(uri: str) -> bool:
+    """Tell if ``uri`` is an RFC 8252 loopback redirect URI (plain-http localhost)."""
+    parts = urlsplit(uri)
+    return parts.scheme == "http" and parts.hostname in ("localhost", "127.0.0.1", "::1")
+
+
+def code_delivery_page(redirect_url: str) -> str:
+    """Interstitial page that delivers the authorization code to a loopback client.
+
+    Browsers can block the cross-scheme ``302 https://issuer → http://localhost``
+    hop (for example Firefox with HTTPS-Only mode). This page navigates with JS,
+    keeps a click-through link (a user gesture succeeds in more configurations),
+    and shows the code for copy-paste as a last resort.
+    """
+    code = parse_qs(urlsplit(redirect_url).query).get("code", [""])[0]
+    # A JSON string literal is a valid JS string literal; escape "<" so the
+    # URL can never close the <script> block.
+    js_url = json.dumps(redirect_url).replace("<", "\\u003c")
+    body = f"""<h1>Authorization complete</h1>
+<p>Returning you to the application…</p>
+<a class="btn" href="{escape(redirect_url)}" rel="noreferrer">Click here if you are not redirected</a>
+<p style="margin:16px 0 0">If the application does not open, paste this code into it:</p>
+<div class="code">{escape(code)}</div>
+<script>location.replace({js_url});</script>"""
+    return _PAGE.format(title="Authorization complete", body=body)

--- a/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
@@ -298,7 +298,9 @@ def register_oauth_endpoints(api: BoltAPI, server: AuthorizationServer) -> None:
         if application_type not in ("web", "native"):
             return _json_error("invalid_client_metadata", "application_type must be 'web' or 'native'")
         if not all(_valid_redirect_uri(uri, application_type=application_type) for uri in redirect_uris):
-            return _json_error("invalid_redirect_uri", "redirect_uris must contain valid absolute URIs without fragments")
+            return _json_error(
+                "invalid_redirect_uri", "redirect_uris must contain valid absolute URIs without fragments"
+            )
         client = await store.create_client(
             client_name=body.get("client_name", ""),
             redirect_uris=redirect_uris,

--- a/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
@@ -126,7 +126,7 @@ def register_oauth_endpoints(api: BoltAPI, server: AuthorizationServer) -> None:
             )
         return client
 
-    async def _issue_code_redirect(p: dict[str, str], client: dict, user: dict, *, session_key: str | None) -> Redirect:
+    async def _issue_code_redirect(p: dict[str, str], client: dict, user: dict, *, session_key: str | None) -> Any:
         code = await store.create_authorization_code(
             client_pk=client["pk"],
             user_id=user["user_id"],
@@ -140,7 +140,9 @@ def register_oauth_endpoints(api: BoltAPI, server: AuthorizationServer) -> None:
         params = {"code": code, "iss": _issuer}
         if p.get("state"):
             params["state"] = p["state"]
-        resp = Redirect(_append_query(p["redirect_uri"], params), status_code=302)
+        # Overridable: a 302, or an interstitial page for loopback redirect URIs
+        # (browsers can block a https → http://localhost redirect). See #307.
+        resp = server.code_redirect_response(_append_query(p["redirect_uri"], params))
         if session_key:
             _apply_session_cookie(resp, session_key)
         return resp

--- a/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
+++ b/python/bolt-mcp/src/bolt_mcp/oauth/endpoints.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from html import escape
 from typing import Any
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlsplit
 
 import msgspec
 from asgiref.sync import sync_to_async
@@ -62,6 +62,23 @@ def _html_error(message: str, *, status: int = 400) -> HTML:
 
 def _append_query(url: str, params: dict[str, str]) -> str:
     return url + ("&" if "?" in url else "?") + urlencode(params)
+
+
+def _valid_redirect_uri(uri: str, *, application_type: str) -> bool:
+    """Reject malformed or relative redirect URIs at registration time."""
+    try:
+        parts = urlsplit(uri)
+        # Accessing hostname/port performs urllib's remaining netloc validation.
+        hostname = parts.hostname
+        _port = parts.port
+    except ValueError:
+        return False
+    if not parts.scheme or parts.fragment:
+        return False
+    if parts.scheme in ("http", "https"):
+        return bool(hostname)
+    # RFC 8252 native clients may use private-use URI schemes, which have no host.
+    return application_type == "native" and bool(parts.path)
 
 
 def _redirect_error(
@@ -280,6 +297,8 @@ def register_oauth_endpoints(api: BoltAPI, server: AuthorizationServer) -> None:
         application_type = body.get("application_type", "web")
         if application_type not in ("web", "native"):
             return _json_error("invalid_client_metadata", "application_type must be 'web' or 'native'")
+        if not all(_valid_redirect_uri(uri, application_type=application_type) for uri in redirect_uris):
+            return _json_error("invalid_redirect_uri", "redirect_uris must contain valid absolute URIs without fragments")
         client = await store.create_client(
             client_name=body.get("client_name", ""),
             redirect_uris=redirect_uris,

--- a/python/bolt-mcp/tests/integration/test_mcp_oauth_integration.py
+++ b/python/bolt-mcp/tests/integration/test_mcp_oauth_integration.py
@@ -26,7 +26,9 @@ pytestmark = pytest.mark.server_integration
 
 DUAL_ACCEPT = "application/json, text/event-stream"
 ISSUER = "http://testserver"
-REDIRECT_URI = "http://localhost:9999/callback"
+# An https redirect URI keeps the plain-302 code delivery; loopback URIs get an
+# interstitial page instead (covered in-process by test_oauth_as.py).
+REDIRECT_URI = "https://client.example.com/callback"
 USERNAME = "alice"
 PASSWORD = "s3cr3t-pw-123456"
 

--- a/python/bolt-mcp/tests/test_oauth_as.py
+++ b/python/bolt-mcp/tests/test_oauth_as.py
@@ -9,6 +9,7 @@ that the issued JWT authenticates to /mcp and drives per-tool guards.
 from __future__ import annotations
 
 import html as html_mod
+import json
 import re
 import secrets
 from urllib.parse import parse_qs, urlsplit
@@ -540,6 +541,13 @@ def _interstitial_target(page: str) -> str:
     return html_mod.unescape(match.group(1))
 
 
+def _interstitial_script_target(page: str) -> str:
+    """The client redirect URL the interstitial's JS navigates to."""
+    match = re.search(r'<script>location\.assign\((".*?")\);</script>', page)
+    assert match, page
+    return json.loads(match.group(1))
+
+
 @pytest.mark.parametrize(
     "redirect_uri",
     [
@@ -564,8 +572,10 @@ def test_loopback_redirect_renders_interstitial_with_working_code(redirect_uri):
         assert q["state"] == ["st-1"]
         assert q["iss"] == [ISSUER]
         code = q["code"][0]
-        assert code in r.text  # visible copy-paste fallback
-        assert "location.assign" in r.text  # JS auto-navigation preserves the fallback in browser history
+        assert f'<div class="code">{code}</div>' in r.text  # visible copy-paste fallback
+        # JS auto-navigation targets the same URL. ``assign`` keeps the page in history,
+        # so the copy-paste fallback stays reachable with the Back button.
+        assert _interstitial_script_target(r.text) == target
         tok = client.post(
             "/oauth/token",
             data={

--- a/python/bolt-mcp/tests/test_oauth_as.py
+++ b/python/bolt-mcp/tests/test_oauth_as.py
@@ -17,6 +17,7 @@ import jwt
 import pytest
 from _helpers import initialize, parse_rpc, post_rpc
 from bolt_mcp import MCP, AuthorizationServer, mount_mcp
+from bolt_mcp.oauth import consent as oauth_consent
 from bolt_mcp.oauth import sessions as oauth_sessions
 from bolt_mcp.oauth.models import RefreshToken
 from bolt_mcp.oauth.pkce import compute_s256, verify_s256
@@ -564,7 +565,7 @@ def test_loopback_redirect_renders_interstitial_with_working_code(redirect_uri):
         assert q["iss"] == [ISSUER]
         code = q["code"][0]
         assert code in r.text  # visible copy-paste fallback
-        assert "location.replace" in r.text  # JS auto-navigation
+        assert "location.assign" in r.text  # JS auto-navigation preserves the fallback in browser history
         tok = client.post(
             "/oauth/token",
             data={
@@ -593,6 +594,29 @@ def test_loopback_interstitial_sets_session_cookie_after_login():
     assert r.status_code == 200, r.text
     assert "sessionid=" in r.headers.get("set-cookie", "")
     assert LOOPBACK_REDIRECT_URI in _interstitial_target(r.text)
+
+
+def test_loopback_interstitial_displays_appended_code_with_existing_query_parameter():
+    page = oauth_consent.code_delivery_page("http://localhost/callback?code=client-value&code=issued-value")
+    assert '<div class="code">issued-value</div>' in page
+    assert '<div class="code">client-value</div>' not in page
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "https://[broken/callback",
+        "https://client.example.com:invalid/callback",
+        "/relative/callback",
+        "https://client.example.com/callback#fragment",
+    ],
+)
+def test_registration_rejects_malformed_redirect_uri(redirect_uri):
+    api, _, _ = _build()
+    with TestClient(api) as client:
+        r = client.post("/oauth/register", json={"redirect_uris": [redirect_uri]})
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_redirect_uri"
 
 
 def test_subclass_overrides_code_redirect_response():
@@ -628,6 +652,16 @@ def test_registration_persists_application_type_native():
         )
     assert r.status_code == 201
     assert r.json()["application_type"] == "native"
+
+
+def test_registration_accepts_native_private_use_redirect_uri():
+    api, _, _ = _build()
+    with TestClient(api) as client:
+        r = client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["com.example.app:/oauth2redirect"], "application_type": "native"},
+        )
+    assert r.status_code == 201
 
 
 def test_registration_defaults_application_type_web():

--- a/python/bolt-mcp/tests/test_oauth_as.py
+++ b/python/bolt-mcp/tests/test_oauth_as.py
@@ -573,8 +573,8 @@ def test_loopback_redirect_renders_interstitial_with_working_code(redirect_uri):
         assert q["iss"] == [ISSUER]
         code = q["code"][0]
         assert f'<div class="code">{code}</div>' in r.text  # visible copy-paste fallback
-        # JS auto-navigation targets the same URL. ``assign`` keeps the page in history,
-        # so the copy-paste fallback stays reachable with the Back button.
+        # The JavaScript navigation goes to the same URL. ``assign`` keeps the page in
+        # history. The Back button thus returns to the copy-paste fallback.
         assert _interstitial_script_target(r.text) == target
         tok = client.post(
             "/oauth/token",

--- a/python/bolt-mcp/tests/test_oauth_as.py
+++ b/python/bolt-mcp/tests/test_oauth_as.py
@@ -8,6 +8,8 @@ that the issued JWT authenticates to /mcp and drives per-tool guards.
 
 from __future__ import annotations
 
+import html as html_mod
+import re
 import secrets
 from urllib.parse import parse_qs, urlsplit
 
@@ -24,10 +26,12 @@ from django.contrib.auth import get_user_model
 
 from django_bolt import BoltAPI, Requires
 from django_bolt.auth import IsAuthenticated, JWTAuthentication
+from django_bolt.responses import Redirect
 from django_bolt.testing import TestClient
 
 ISSUER = "http://localhost:8000"
-REDIRECT_URI = "http://localhost:9876/callback"
+REDIRECT_URI = "https://client.example.com/callback"
+LOOPBACK_REDIRECT_URI = "http://localhost:9876/callback"
 PASSWORD = "s3cr3t-pw-123456"
 
 
@@ -510,6 +514,105 @@ def test_denied_consent_redirect_carries_iss():
     q = parse_qs(urlsplit(r.headers["location"]).query)
     assert q["error"] == ["access_denied"]
     assert q["iss"] == [ISSUER]
+
+
+# ── loopback code delivery (issue #307) ─────────────────────────────────────────
+# A raw ``302 https://issuer → http://localhost`` redirect can be upgraded or
+# blocked by the browser (Firefox HTTPS-Only mode). Loopback redirect URIs get an
+# interstitial page instead; https redirect URIs keep the plain 302 (covered by
+# the tests above, which use an https REDIRECT_URI).
+
+
+def _approve(client, params, username="alice"):
+    return client.post(
+        "/oauth/authorize",
+        data={**params, "decision": "approve"},
+        headers={**_session_cookie(username), "Origin": ISSUER},
+        follow_redirects=False,
+    )
+
+
+def _interstitial_target(page: str) -> str:
+    """The client redirect URL the interstitial links to."""
+    match = re.search(r'href="([^"]+)"', page)
+    assert match, page
+    return html_mod.unescape(match.group(1))
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://localhost:9876/callback",
+        "http://127.0.0.1:9876/callback",
+        "http://[::1]:9876/callback",
+    ],
+)
+def test_loopback_redirect_renders_interstitial_with_working_code(redirect_uri):
+    api, _, _ = _build()
+    with TestClient(api) as client:
+        _make_user()
+        client_id = _register_client(client, redirect_uris=[redirect_uri])
+        verifier, challenge = _pkce()
+        r = _approve(client, _authorize_params(client_id, challenge, redirect_uri=redirect_uri))
+        assert r.status_code == 200, r.text
+        assert "location" not in {k.lower() for k in r.headers}
+        assert "no-store" in r.headers.get("cache-control", "")
+        target = _interstitial_target(r.text)
+        assert target.startswith(redirect_uri + "?")
+        q = parse_qs(urlsplit(target).query)
+        assert q["state"] == ["st-1"]
+        assert q["iss"] == [ISSUER]
+        code = q["code"][0]
+        assert code in r.text  # visible copy-paste fallback
+        assert "location.replace" in r.text  # JS auto-navigation
+        tok = client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "code_verifier": verifier,
+            },
+        )
+        assert tok.status_code == 200, tok.text
+
+
+def test_loopback_interstitial_sets_session_cookie_after_login():
+    api, _, _ = _build(auto_consent=True)
+    _make_user()
+    with TestClient(api) as client:
+        client_id = _register_client(client, redirect_uris=[LOOPBACK_REDIRECT_URI])
+        _, challenge = _pkce()
+        form = {
+            **_authorize_params(client_id, challenge, redirect_uri=LOOPBACK_REDIRECT_URI),
+            "username": "alice",
+            "password": PASSWORD,
+        }
+        r = client.post("/oauth/authorize", data=form, headers={"Origin": ISSUER}, follow_redirects=False)
+    assert r.status_code == 200, r.text
+    assert "sessionid=" in r.headers.get("set-cookie", "")
+    assert LOOPBACK_REDIRECT_URI in _interstitial_target(r.text)
+
+
+def test_subclass_overrides_code_redirect_response():
+    class SeeOtherAuth(AuthorizationServer):
+        issuer = ISSUER
+
+        def code_redirect_response(self, redirect_url):
+            # 303: distinguishable from both the default 302 and the interstitial.
+            return Redirect(redirect_url, status_code=303)
+
+    api = _mount_subclass(SeeOtherAuth)
+    with TestClient(api) as client:
+        _make_user()
+        client_id = _register_client(client, redirect_uris=[LOOPBACK_REDIRECT_URI])
+        _, challenge = _pkce()
+        r = _approve(client, _authorize_params(client_id, challenge, redirect_uri=LOOPBACK_REDIRECT_URI))
+    # The override wins even for a loopback redirect URI.
+    assert r.status_code == 303, r.text
+    q = parse_qs(urlsplit(r.headers["location"]).query)
+    assert q["code"] and q["iss"] == [ISSUER]
 
 
 def test_registration_persists_application_type_native():

--- a/python/example/mcp_demo/api.py
+++ b/python/example/mcp_demo/api.py
@@ -20,6 +20,7 @@ issues a GET (reserved for the server→client SSE channel) and returns an error
 from __future__ import annotations
 
 import asyncio
+import os
 
 import msgspec
 from bolt_mcp import MCP, AuthorizationServer, Context, principal
@@ -180,7 +181,9 @@ class ExampleMcpAuth(AuthorizationServer):
     # it is baked into every issued token and discovery document, and the client follows
     # it byte-for-byte through the OAuth handshake. This demo is run with
     # `runbolt --port 8001`, so the issuer is 127.0.0.1:8001; change it if you change either.
-    issuer = "http://127.0.0.1:8001"
+    # Set MCP_ISSUER to run behind a TLS terminator, for example
+    # MCP_ISSUER=https://localhost:8443.
+    issuer = os.environ.get("MCP_ISSUER", "http://127.0.0.1:8001")
 
     def get_extra_claims(self, user, *, scopes, client_id):
         # Map the signed-in Django user to the permissions the guarded tools check.

--- a/python/example/mcp_oauth_client_demo.py
+++ b/python/example/mcp_oauth_client_demo.py
@@ -34,13 +34,14 @@ import argparse
 import base64
 import hashlib
 import json
+import re
 import secrets
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 
-REDIRECT_URI = "http://127.0.0.1:8765/callback"  # never actually served; we read the 302
+REDIRECT_URI = "http://127.0.0.1:8765/callback"  # never served; we read the code out of the response
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -71,6 +72,23 @@ def post_form(url: str, fields: dict, *, headers: dict | None = None):
     data = urllib.parse.urlencode(fields).encode()
     hdrs = {"Content-Type": "application/x-www-form-urlencoded", **(headers or {})}
     return http("POST", url, data=data, headers=hdrs)
+
+
+def code_url(resp, body: bytes) -> str:
+    """Return the client redirect URL (with ``code``) from a post-consent response.
+
+    A browser gets one of two shapes. An ``https`` redirect URI gets a plain 302.
+    A loopback redirect URI (``http://localhost`` / ``127.0.0.1``) gets a 200
+    interstitial page on the issuer origin, because some browsers block the
+    ``https → http://localhost`` 302. The page navigates with JS. This script has
+    no JS engine, so it reads the same URL out of the page markup.
+    """
+    if resp.status == 302:
+        return resp.headers["Location"]
+    match = re.search(r'<script>location\.(?:assign|replace)\((".*?")\);</script>', body.decode())
+    if not match:
+        sys.exit(f"no code in the post-consent response: {resp.status} {body[:500]!r}")
+    return json.loads(match.group(1))
 
 
 def step(n: int, text: str) -> None:
@@ -156,9 +174,10 @@ def main() -> None:
             {**oauth_params, "decision": "approve"},
             headers={"Origin": issuer, "Cookie": cookie},
         )
-        if consent.status != 302:
-            sys.exit(f"consent failed: {consent.status} {consent.read()[:500]!r}")
-        location = consent.headers["Location"]
+        consent_body = consent.read()
+        if consent.status not in (200, 302):
+            sys.exit(f"consent failed: {consent.status} {consent_body[:500]!r}")
+        location = code_url(consent, consent_body)
     else:
         sys.exit(f"authorize failed: {login.status} {login_body[:500]!r}")
 

--- a/python/example/mcp_oauth_client_demo.py
+++ b/python/example/mcp_oauth_client_demo.py
@@ -74,21 +74,32 @@ def post_form(url: str, fields: dict, *, headers: dict | None = None):
     return http("POST", url, data=data, headers=hdrs)
 
 
-def code_url(resp, body: bytes) -> str:
-    """Return the client redirect URL (with ``code``) from a post-consent response.
+_INTERSTITIAL_SCRIPT = re.compile(r'<script>location\.(?:assign|replace)\((".*?")\);</script>')
 
-    A browser gets one of two shapes. An ``https`` redirect URI gets a plain 302.
+
+def interstitial_url(body: bytes) -> str | None:
+    """Return the client redirect URL if ``body`` is a code-delivery interstitial.
+
     A loopback redirect URI (``http://localhost`` / ``127.0.0.1``) gets a 200
     interstitial page on the issuer origin, because some browsers block the
     ``https → http://localhost`` 302. The page navigates with JS. This script has
     no JS engine, so it reads the same URL out of the page markup.
     """
+    match = _INTERSTITIAL_SCRIPT.search(body.decode())
+    return json.loads(match.group(1)) if match else None
+
+
+def code_url(resp, body: bytes) -> str:
+    """Return the client redirect URL (with ``code``) from a post-consent response.
+
+    An ``https`` redirect URI gets a plain 302. A loopback one gets the interstitial.
+    """
     if resp.status == 302:
         return resp.headers["Location"]
-    match = re.search(r'<script>location\.(?:assign|replace)\((".*?")\);</script>', body.decode())
-    if not match:
+    url = interstitial_url(body)
+    if url is None:
         sys.exit(f"no code in the post-consent response: {resp.status} {body[:500]!r}")
-    return json.loads(match.group(1))
+    return url
 
 
 def step(n: int, text: str) -> None:
@@ -163,6 +174,11 @@ def main() -> None:
         location = login.headers["Location"]
     elif login.status == 200 and b"Invalid username or password" in login_body:
         sys.exit("login failed: invalid username or password (create the user first — see README)")
+    elif login.status == 200 and (login_interstitial := interstitial_url(login_body)):
+        # auto_consent server + loopback redirect URI: the login response is already the
+        # code-delivery interstitial, not a consent page. Approving again would make the
+        # server issue a second, redundant authorization code.
+        location = login_interstitial
     elif login.status == 200:
         # ── 4. consent screen: approve with the session cookie ────────────────
         step(4, "consent: approve")

--- a/python/example/mcp_oauth_client_demo.py
+++ b/python/example/mcp_oauth_client_demo.py
@@ -175,9 +175,9 @@ def main() -> None:
     elif login.status == 200 and b"Invalid username or password" in login_body:
         sys.exit("login failed: invalid username or password (create the user first — see README)")
     elif login.status == 200 and (login_interstitial := interstitial_url(login_body)):
-        # auto_consent server + loopback redirect URI: the login response is already the
-        # code-delivery interstitial, not a consent page. Approving again would make the
-        # server issue a second, redundant authorization code.
+        # With auto_consent and a loopback redirect URI, the login response is already
+        # the code-delivery interstitial. It is not a consent page. A second approval
+        # would make the server issue a redundant authorization code.
         location = login_interstitial
     elif login.status == 200:
         # ── 4. consent screen: approve with the session cookie ────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -1120,11 +1120,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #307

After consent, loopback redirect URIs (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) now receive an interstitial page on the issuer origin instead of a plain 302 redirect. Browsers such as Firefox with HTTPS-Only mode block the `https → http://localhost` 302 hop, making the "Allow" button appear to do nothing. The interstitial page navigates via JavaScript, provides a click-through link as a fallback, and displays the authorization code for copy-paste as a last resort.

**Changes:**

- Add `is_loopback_uri()` and `code_delivery_page()` to `consent.py` to detect loopback URIs and render the interstitial.
- Add `code_redirect_response()` method to `AuthorizationServer` (overridable) that returns either the interstitial page for loopback URIs or a plain 302 for HTTPS URIs.
- Update `/authorize` endpoint to use `code_redirect_response()` instead of hardcoded 302.
- Update test fixtures to use HTTPS redirect URIs by default; add `LOOPBACK_REDIRECT_URI` for loopback-specific tests.
- Add comprehensive tests for loopback interstitial behavior, session cookie handling, and subclass override.

## How was this tested?

- [x] `just lint-lib` and `just test-py` pass
- [x] Added 3 new test functions covering loopback interstitial rendering, session cookies, and subclass override
- [x] Existing OAuth tests updated to use HTTPS redirect URIs (plain 302 path)

https://claude.ai/code/session_01BNPaZ6q156uqibtCG8zhFX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path assessment

Yes. The PR changes the `/authorize` post-consent redirect path through `_issue_code_redirect()`.

The added work is limited to:

- Calling `server.code_redirect_response()`.
- Validating and checking the redirect URI.
- Rendering interstitial HTML only for loopback HTTP redirects.
- Preserving session-cookie handling.

This work is required for loopback OAuth code delivery. HTTPS redirects still use a plain `302` response. Normal authorization requests do not render the interstitial.

The main overhead is URI parsing and HTML generation for loopback responses. This overhead applies only after consent and only when a loopback redirect is used. No unnecessary hot-path work is indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->