### PR TITLE
feat(rate-limit): implement key="user" and key="api_key"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`@rate_limit(key="user")` and `key="api_key"` count per identity** - Both keys were documented but never implemented. They fell into the header catch-all, matched no header, and resolved to one shared bucket. A route marked "per user" was one global limit that one caller could exhaust for everyone. Both keys now run after authentication and count per `AuthContext` identity: any backend for `"user"`, API keys only for `"api_key"`. A caller with no identity is counted per client address. A route with an identity key and no auth backend fails at startup. `key="ip"` and header keys still run before authentication. (#301)
+
 ### Security
 
 - **`@rate_limit(key="ip")` trusted `X-Forwarded-For`** - The key came from the leftmost entry of `X-Forwarded-For`, which the client sends. Behind a proxy that appends the header, and with Bolt exposed directly, a client changed one header and got a new bucket for every request. Bolt now uses one canonical client address for rate limiting, `request.META["REMOTE_ADDR"]`, and request logging: the peer address by default, or the first untrusted `X-Forwarded-For` hop when the peer matches `BOLT_TRUSTED_PROXIES`. Malformed chains fall back to the peer. **Add the setting if you run behind a proxy**, or every caller behind it shares one bucket. (#302)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Rate-limit buckets key on a hash** - A bucket key was stored as its own text. The map now holds an 8-byte hash of it, seeded once per process so a caller cannot craft a value that lands in another caller's bucket. Nothing is allocated per request, and the identity path matches the `key="ip"` path. This removes the 256-byte limit on a key: `@rate_limit(key="<header>")` with a long value, such as `key="authorization"` with a JWT, returned `400 Rate limit key too long` and now counts like any other value. (#301)
+
 - **`@rate_limit(key="user")` and `key="api_key"` count per identity** - Both keys were documented but never implemented. They fell into the header catch-all, matched no header, and resolved to one shared bucket. A route marked "per user" was one global limit that one caller could exhaust for everyone. Both keys now run after authentication and count per `AuthContext` identity: any backend for `"user"`, API keys only for `"api_key"`. A caller with no identity is counted per client address. A route with an identity key and no auth backend fails at startup. `key="ip"` and header keys still run before authentication. (#301)
 
 ### Security

--- a/crates/bolt-core/src/metadata.rs
+++ b/crates/bolt-core/src/metadata.rs
@@ -224,6 +224,19 @@ pub enum RateLimitKey {
     Ip,
     /// One request header, stored lowercase for direct lookup.
     Header(String),
+    /// The authenticated identity from any backend (`AuthContext::user_id`).
+    /// Runs after authentication. No identity falls back to the client address.
+    User,
+    /// The authenticated API key. Other backends do not count as an identity.
+    ApiKey,
+}
+
+impl RateLimitKey {
+    /// `User` and `ApiKey` need an `AuthContext`, so their check runs after
+    /// authentication instead of before it.
+    pub const fn needs_identity(&self) -> bool {
+        matches!(self, RateLimitKey::User | RateLimitKey::ApiKey)
+    }
 }
 
 impl Default for RateLimitConfig {
@@ -664,6 +677,20 @@ impl RouteMetadata {
         let guards = GuardSet::from_guards(guards);
         let has_auth_or_guards = !auth_backends.is_empty() || guards.is_enforcing();
         let has_rate_limit = rate_limit_config.is_some();
+        // An identity key with no backend can never see an identity. Every
+        // caller would share the address bucket, so refuse to start.
+        if let Some(config) = &rate_limit_config {
+            if config.key.needs_identity() && auth_backends.is_empty() {
+                let key = match config.key {
+                    RateLimitKey::User => "user",
+                    _ => "api_key",
+                };
+                return Err(PyValueError::new_err(format!(
+                    "@rate_limit(key=\"{key}\") needs an auth backend on the route or the API; \
+                     without one there is no identity to count per. Use key=\"ip\" or a header name."
+                )));
+            }
+        }
         let can_sync_dispatch = py_meta
             .get_item("can_sync_dispatch")
             .ok()
@@ -866,10 +893,11 @@ fn parse_rate_limit_config(
     // check can look them up directly (headers are stored lowercase).
     if let Some(key_py) = dict.get("key") {
         if let Ok(key_type) = key_py.extract::<String>(py) {
-            config.key = if key_type.eq_ignore_ascii_case("ip") {
-                RateLimitKey::Ip
-            } else {
-                RateLimitKey::Header(key_type.to_lowercase())
+            config.key = match key_type.to_lowercase().as_str() {
+                "ip" => RateLimitKey::Ip,
+                "user" => RateLimitKey::User,
+                "api_key" => RateLimitKey::ApiKey,
+                header => RateLimitKey::Header(header.to_owned()),
             };
         }
     }

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -58,12 +58,20 @@ impl KeySource<'_> {
     }
 }
 
+/// What the rejection log is allowed to name. Never the key material: the
+/// `api_key` backend stores the raw credential in `AuthContext::user_id`
+/// (`AuthContext::from_api_key`), and a header key may hold an `Authorization`
+/// value. Both would otherwise reach stderr on a 429.
+///
+/// A bucket keeps one label for the life of the process, so an operator can
+/// still see that the same caller keeps hitting the limit.
 impl fmt::Display for KeySource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            // An address is not a credential, and is the useful thing to read.
             KeySource::Ip(ip) => ip.fmt(f),
-            KeySource::Header(value) => f.write_str(value),
-            KeySource::Identity(value) => f.write_str(value),
+            KeySource::Header(_) => write!(f, "header:{:016x}", self.bucket().0),
+            KeySource::Identity(_) => write!(f, "identity:{:016x}", self.bucket().0),
             KeySource::Unknown => f.write_str("unknown"),
         }
     }
@@ -299,6 +307,42 @@ mod tests {
             KeySource::Header(&long_a).bucket(),
             KeySource::Header(&long_b).bucket()
         );
+    }
+
+    #[test]
+    fn the_log_label_never_carries_key_material() {
+        // `AuthContext::from_api_key` stores `apikey:<raw key>` in `user_id`,
+        // and a header key may be an `Authorization` value. Neither may reach
+        // the rejection log.
+        let secret = "sk-live-DO-NOT-LOG-4f2b9c";
+
+        let identity = KeySource::Identity(&format!("apikey:{secret}")).to_string();
+        assert!(
+            !identity.contains(secret),
+            "identity label leaked: {identity}"
+        );
+        assert!(
+            identity.starts_with("identity:"),
+            "unexpected label: {identity}"
+        );
+
+        let header = KeySource::Header(&format!("Bearer {secret}")).to_string();
+        assert!(!header.contains(secret), "header label leaked: {header}");
+        assert!(header.starts_with("header:"), "unexpected label: {header}");
+    }
+
+    #[test]
+    fn the_log_label_still_identifies_one_caller() {
+        // An operator has to see that the same caller keeps being limited.
+        let one = KeySource::Identity("apikey:aaa").to_string();
+        let same = KeySource::Identity("apikey:aaa").to_string();
+        let other = KeySource::Identity("apikey:bbb").to_string();
+        assert_eq!(one, same);
+        assert_ne!(one, other);
+
+        // An address is not a credential, and is the useful thing to read.
+        assert_eq!(KeySource::Ip(ip("203.0.113.7")).to_string(), "203.0.113.7");
+        assert_eq!(KeySource::Unknown.to_string(), "unknown");
     }
 
     #[test]

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -1,11 +1,12 @@
 use actix_web::HttpResponse;
-use ahash::AHashMap;
+use ahash::{AHashMap, RandomState};
 use dashmap::DashMap;
 use governor::clock::{Clock, DefaultClock};
 use governor::state::{InMemoryState, NotKeyed};
 use governor::{Quota, RateLimiter};
 use once_cell::sync::Lazy;
 use std::fmt;
+use std::hash::{BuildHasher, Hash, Hasher};
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -17,23 +18,53 @@ use crate::responses;
 
 type Limiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
 
-/// One bucket identity. `Ip` is `Copy`, so the common path hashes 17 bytes
-/// and never allocates. `Header` owns its value because it is the map key.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum LimiterKey {
+/// Seeds the bucket hash once per process. A caller must not be able to pick
+/// a key that lands in another caller's bucket, so the map from key material
+/// to bucket is not predictable from outside the process. Buckets are already
+/// per-process, so the seed does not need to agree across workers.
+static KEY_HASHER: Lazy<RandomState> = Lazy::new(RandomState::new);
+
+/// One bucket identity, hashed to 8 bytes. The map holds no key material, so
+/// nothing is allocated per request and a long header value costs the same as
+/// an address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct LimiterKey(u64);
+
+/// Where a bucket key comes from. This borrows the key material rather than
+/// owning it, so resolving one allocates nothing. The rejection path can still
+/// name the key, which keeps formatting off the hot path.
+#[derive(Debug, Clone, Copy)]
+enum KeySource<'a> {
     Ip(IpAddr),
-    Header(Box<str>),
-    Identity(Box<str>),
+    Header(&'a str),
+    Identity(&'a str),
     Unknown,
 }
 
-impl fmt::Display for LimiterKey {
+impl KeySource<'_> {
+    /// The map key. The leading tag keeps two sources apart on one route: an
+    /// identity-keyed route falls back to the address, and an identity that
+    /// reads like an address must not join that address bucket.
+    #[inline]
+    fn bucket(&self) -> LimiterKey {
+        let mut hasher = KEY_HASHER.build_hasher();
+        match self {
+            KeySource::Ip(ip) => (0u8, ip).hash(&mut hasher),
+            KeySource::Header(value) => (1u8, value).hash(&mut hasher),
+            KeySource::Identity(value) => (2u8, value).hash(&mut hasher),
+            KeySource::Unknown => 3u8.hash(&mut hasher),
+        }
+        LimiterKey(hasher.finish())
+    }
+}
+
+impl fmt::Display for KeySource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LimiterKey::Ip(ip) => ip.fmt(f),
-            LimiterKey::Header(value) => f.write_str(value),
-            LimiterKey::Identity(value) => f.write_str(value),
-            LimiterKey::Unknown => f.write_str("unknown"),
+            KeySource::Ip(ip) => ip.fmt(f),
+            KeySource::Header(value) => f.write_str(value),
+            KeySource::Identity(value) => f.write_str(value),
+            KeySource::Unknown => f.write_str("unknown"),
         }
     }
 }
@@ -41,7 +72,7 @@ impl fmt::Display for LimiterKey {
 /// Per-key limiters. The quota is part of the identity: handler ids are reused
 /// after a reload or by the next test app, and a stale limiter must not keep
 /// an old quota alive.
-static IP_LIMITERS: Lazy<DashMap<(usize, u32, u32, LimiterKey), Arc<Limiter>>> =
+static LIMITERS: Lazy<DashMap<(usize, u32, u32, LimiterKey), Arc<Limiter>>> =
     Lazy::new(DashMap::new);
 
 // Track total limiter count for cleanup
@@ -49,9 +80,6 @@ static LIMITER_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 // SECURITY: Maximum number of rate limiters to prevent memory exhaustion
 const MAX_LIMITERS: usize = 100_000;
-
-// SECURITY: Maximum key length to prevent memory attacks
-const MAX_KEY_LENGTH: usize = 256;
 
 /// The check for address and header keys. Runs before authentication so a
 /// flood never pays for token verification. Identity keys return `None` here.
@@ -102,29 +130,24 @@ pub fn check_rate_limit(
     let burst = config.burst;
 
     // Determine the rate limit key
-    let key = match &config.key {
-        RateLimitKey::Ip => client_ip.map(|ip| LimiterKey::Ip(*ip)),
+    let source = match &config.key {
+        RateLimitKey::Ip => client_ip.map(|ip| KeySource::Ip(*ip)),
         // Custom header key — already lowercased once at startup when the
         // RateLimitConfig was parsed (headers map stores lowercase names).
-        RateLimitKey::Header(name) => match headers.get(name) {
-            // SECURITY: Validate key length to prevent memory attacks
-            Some(value) if value.len() > MAX_KEY_LENGTH => {
-                return Some(
-                    HttpResponse::BadRequest()
-                        .content_type("application/json")
-                        .body(r#"{"detail":"Rate limit key too long"}"#),
-                );
-            }
-            Some(value) => Some(LimiterKey::Header(value.as_str().into())),
-            None => None,
-        },
+        // The value is hashed rather than stored, so its length is not capped:
+        // `key="authorization"` with a JWT works.
+        RateLimitKey::Header(name) => headers
+            .get(name)
+            .map(|value| KeySource::Header(value.as_str())),
         // Identity keys run after authentication. A caller with no identity
         // is limited per client address, so an unauthenticated flood cannot
         // pick a fresh bucket per request.
-        RateLimitKey::User => identity_key(auth_ctx, client_ip, |_| true),
-        RateLimitKey::ApiKey => identity_key(auth_ctx, client_ip, |ctx| ctx.backend == "api_key"),
+        RateLimitKey::User => identity_source(auth_ctx, client_ip, |_| true),
+        RateLimitKey::ApiKey => {
+            identity_source(auth_ctx, client_ip, |ctx| ctx.backend == "api_key")
+        }
     }
-    .unwrap_or(LimiterKey::Unknown);
+    .unwrap_or(KeySource::Unknown);
 
     // SECURITY: Check if we've exceeded max limiters (prevent memory exhaustion)
     let current_count = LIMITER_COUNT.load(Ordering::Relaxed);
@@ -134,8 +157,8 @@ pub fn check_rate_limit(
     }
 
     // Get or create rate limiter for this handler + key combination
-    let limiter = IP_LIMITERS
-        .entry((handler_id, rps, burst, key))
+    let limiter = LIMITERS
+        .entry((handler_id, rps, burst, source.bucket()))
         .or_insert_with(|| {
             // Increment counter
             LIMITER_COUNT.fetch_add(1, Ordering::Relaxed);
@@ -158,7 +181,7 @@ pub fn check_rate_limit(
             // Log rate limit exceeded
             eprintln!(
                 "[django-bolt] Rate limit exceeded: {} {} | key: {} | limit: {} rps (burst: {}) | retry after: {}s",
-                method, path, limiter.key().3, rps, burst, retry_after
+                method, path, source, rps, burst, retry_after
             );
 
             Some(response_builder::build_rate_limit_response(
@@ -174,16 +197,16 @@ pub fn check_rate_limit(
 /// The authenticated identity when `accept` admits the backend, else the
 /// client address.
 #[inline]
-fn identity_key(
-    auth_ctx: Option<&AuthContext>,
+fn identity_source<'a>(
+    auth_ctx: Option<&'a AuthContext>,
     client_ip: Option<&IpAddr>,
     accept: impl Fn(&AuthContext) -> bool,
-) -> Option<LimiterKey> {
+) -> Option<KeySource<'a>> {
     auth_ctx
         .filter(|ctx| accept(ctx))
         .and_then(|ctx| ctx.user_id.as_deref())
-        .map(|id| LimiterKey::Identity(id.into()))
-        .or_else(|| client_ip.map(|ip| LimiterKey::Ip(*ip)))
+        .map(KeySource::Identity)
+        .or_else(|| client_ip.map(|ip| KeySource::Ip(*ip)))
 }
 
 /// Cleanup old rate limiters when limit is reached
@@ -193,7 +216,7 @@ fn cleanup_old_limiters() {
     let mut removed = 0;
 
     // Remove first N entries (simple cleanup, not LRU)
-    IP_LIMITERS.retain(|_, _| {
+    LIMITERS.retain(|_, _| {
         if removed < to_remove {
             removed += 1;
             LIMITER_COUNT.fetch_sub(1, Ordering::Relaxed);
@@ -202,4 +225,90 @@ fn cleanup_old_limiters() {
             true // Keep this entry
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(value: &str) -> IpAddr {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn same_key_material_lands_in_one_bucket() {
+        assert_eq!(
+            KeySource::Header("tenant-a").bucket(),
+            KeySource::Header("tenant-a").bucket()
+        );
+        assert_eq!(
+            KeySource::Ip(ip("203.0.113.7")).bucket(),
+            KeySource::Ip(ip("203.0.113.7")).bucket()
+        );
+        assert_eq!(KeySource::Unknown.bucket(), KeySource::Unknown.bucket());
+    }
+
+    #[test]
+    fn different_key_material_lands_in_different_buckets() {
+        assert_ne!(
+            KeySource::Header("tenant-a").bucket(),
+            KeySource::Header("tenant-b").bucket()
+        );
+        assert_ne!(
+            KeySource::Ip(ip("203.0.113.7")).bucket(),
+            KeySource::Ip(ip("203.0.113.8")).bucket()
+        );
+        assert_ne!(
+            KeySource::Identity("7").bucket(),
+            KeySource::Identity("8").bucket()
+        );
+    }
+
+    #[test]
+    fn the_tag_keeps_two_sources_apart() {
+        // An identity-keyed route falls back to the address, so both sources
+        // reach one map. An identity that reads like an address must not join
+        // that address bucket.
+        assert_ne!(
+            KeySource::Identity("203.0.113.7").bucket(),
+            KeySource::Ip(ip("203.0.113.7")).bucket()
+        );
+        assert_ne!(
+            KeySource::Header("203.0.113.7").bucket(),
+            KeySource::Ip(ip("203.0.113.7")).bucket()
+        );
+        assert_ne!(
+            KeySource::Header("unknown").bucket(),
+            KeySource::Unknown.bucket()
+        );
+    }
+
+    #[test]
+    fn a_long_key_is_accepted_and_stays_distinct() {
+        // Nothing caps the length now: the map holds the hash, not the value.
+        // `key="authorization"` with a JWT goes through here.
+        let long_a = "t".repeat(4096);
+        let long_b = format!("{}x", "t".repeat(4095));
+        assert_eq!(
+            KeySource::Header(&long_a).bucket(),
+            KeySource::Header(&long_a).bucket()
+        );
+        assert_ne!(
+            KeySource::Header(&long_a).bucket(),
+            KeySource::Header(&long_b).bucket()
+        );
+    }
+
+    #[test]
+    fn concatenation_does_not_collide() {
+        // "ab" + "c" must not hash like "a" + "bc".
+        assert_ne!(
+            KeySource::Header("ab").bucket(),
+            KeySource::Header("a").bucket()
+        );
+        assert_ne!(
+            KeySource::Identity("ab").bucket(),
+            KeySource::Identity("a").bucket()
+        );
+    }
 }

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -113,7 +113,9 @@ pub fn check_after_auth(
     if !config.key.needs_identity() {
         return None;
     }
-    check_rate_limit(handler_id, headers, client_ip, auth_ctx, config, method, path)
+    check_rate_limit(
+        handler_id, headers, client_ip, auth_ctx, config, method, path,
+    )
 }
 
 pub fn check_rate_limit(

--- a/crates/bolt-core/src/middleware/rate_limit.rs
+++ b/crates/bolt-core/src/middleware/rate_limit.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::metadata::{RateLimitConfig, RateLimitKey};
+use crate::middleware::auth::AuthContext;
 use crate::response_builder;
 use crate::responses;
 
@@ -22,6 +23,7 @@ type Limiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
 enum LimiterKey {
     Ip(IpAddr),
     Header(Box<str>),
+    Identity(Box<str>),
     Unknown,
 }
 
@@ -30,6 +32,7 @@ impl fmt::Display for LimiterKey {
         match self {
             LimiterKey::Ip(ip) => ip.fmt(f),
             LimiterKey::Header(value) => f.write_str(value),
+            LimiterKey::Identity(value) => f.write_str(value),
             LimiterKey::Unknown => f.write_str("unknown"),
         }
     }
@@ -50,10 +53,46 @@ const MAX_LIMITERS: usize = 100_000;
 // SECURITY: Maximum key length to prevent memory attacks
 const MAX_KEY_LENGTH: usize = 256;
 
+/// The check for address and header keys. Runs before authentication so a
+/// flood never pays for token verification. Identity keys return `None` here.
+#[inline]
+pub fn check_before_auth(
+    handler_id: usize,
+    headers: &AHashMap<String, String>,
+    client_ip: Option<&IpAddr>,
+    config: &RateLimitConfig,
+    method: &str,
+    path: &str,
+) -> Option<HttpResponse> {
+    if config.key.needs_identity() {
+        return None;
+    }
+    check_rate_limit(handler_id, headers, client_ip, None, config, method, path)
+}
+
+/// The check for identity keys. Runs after authentication, with the
+/// `AuthContext` of the request. Other keys return `None` here.
+#[inline]
+pub fn check_after_auth(
+    handler_id: usize,
+    headers: &AHashMap<String, String>,
+    client_ip: Option<&IpAddr>,
+    auth_ctx: Option<&AuthContext>,
+    config: &RateLimitConfig,
+    method: &str,
+    path: &str,
+) -> Option<HttpResponse> {
+    if !config.key.needs_identity() {
+        return None;
+    }
+    check_rate_limit(handler_id, headers, client_ip, auth_ctx, config, method, path)
+}
+
 pub fn check_rate_limit(
     handler_id: usize,
     headers: &AHashMap<String, String>,
     client_ip: Option<&IpAddr>,
+    auth_ctx: Option<&AuthContext>,
     config: &RateLimitConfig,
     method: &str,
     path: &str,
@@ -79,6 +118,11 @@ pub fn check_rate_limit(
             Some(value) => Some(LimiterKey::Header(value.as_str().into())),
             None => None,
         },
+        // Identity keys run after authentication. A caller with no identity
+        // is limited per client address, so an unauthenticated flood cannot
+        // pick a fresh bucket per request.
+        RateLimitKey::User => identity_key(auth_ctx, client_ip, |_| true),
+        RateLimitKey::ApiKey => identity_key(auth_ctx, client_ip, |ctx| ctx.backend == "api_key"),
     }
     .unwrap_or(LimiterKey::Unknown);
 
@@ -125,6 +169,21 @@ pub fn check_rate_limit(
             ))
         }
     }
+}
+
+/// The authenticated identity when `accept` admits the backend, else the
+/// client address.
+#[inline]
+fn identity_key(
+    auth_ctx: Option<&AuthContext>,
+    client_ip: Option<&IpAddr>,
+    accept: impl Fn(&AuthContext) -> bool,
+) -> Option<LimiterKey> {
+    auth_ctx
+        .filter(|ctx| accept(ctx))
+        .and_then(|ctx| ctx.user_id.as_deref())
+        .map(|id| LimiterKey::Identity(id.into()))
+        .or_else(|| client_ip.map(|ip| LimiterKey::Ip(*ip)))
 }
 
 /// Cleanup old rate limiters when limit is reached

--- a/crates/bolt-core/tests/rate_limit_allocations.rs
+++ b/crates/bolt-core/tests/rate_limit_allocations.rs
@@ -1,0 +1,97 @@
+//! Allocations per rate-limited request.
+//!
+//! The RPS difference from hashing the bucket key is smaller than the noise
+//! of an HTTP benchmark. This counts the mechanism instead, which is what the
+//! change is about. See `docs/PROFILING.md`, "Allocation counting".
+
+use ahash::AHashMap;
+use bolt_core::metadata::{RateLimitConfig, RateLimitKey};
+use bolt_core::middleware::rate_limit::check_before_auth;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+thread_local! {
+    // Per thread, so tests running in parallel do not count each other.
+    // Const-initialized: a lazy one would allocate inside the allocator.
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // `try_with` because TLS is gone late in thread teardown.
+        let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Allocations made on this thread while `body` runs.
+fn count(body: impl FnOnce()) -> usize {
+    let before = ALLOCATIONS.with(|count| count.get());
+    body();
+    ALLOCATIONS.with(|count| count.get()) - before
+}
+
+fn headers(value: &str) -> AHashMap<String, String> {
+    let mut map = AHashMap::new();
+    map.insert("x-tenant".to_string(), value.to_string());
+    map
+}
+
+#[test]
+fn a_header_keyed_request_allocates_nothing() {
+    let config = RateLimitConfig {
+        rps: 1_000_000,
+        burst: 1_000_000,
+        key: RateLimitKey::Header("x-tenant".to_string()),
+    };
+    let map = headers("acme");
+
+    // The first request creates the limiter for this bucket, which allocates.
+    // Steady state is what a served request costs.
+    check_before_auth(9_001, &map, None, &config, "GET", "/limited");
+
+    let allocations = count(|| {
+        for _ in 0..1_000 {
+            assert!(check_before_auth(9_001, &map, None, &config, "GET", "/limited").is_none());
+        }
+    });
+
+    assert_eq!(
+        allocations, 0,
+        "expected no allocation per request, got {allocations} over 1000 requests"
+    );
+}
+
+#[test]
+fn a_long_header_value_allocates_nothing_either() {
+    // The old code copied the value into the map key, so cost grew with it.
+    // It also refused anything over 256 bytes.
+    let config = RateLimitConfig {
+        rps: 1_000_000,
+        burst: 1_000_000,
+        key: RateLimitKey::Header("x-tenant".to_string()),
+    };
+    let map = headers(&"t".repeat(4096));
+
+    check_before_auth(9_002, &map, None, &config, "GET", "/limited");
+
+    let allocations = count(|| {
+        for _ in 0..1_000 {
+            assert!(check_before_auth(9_002, &map, None, &config, "GET", "/limited").is_none());
+        }
+    });
+
+    assert_eq!(
+        allocations, 0,
+        "expected no allocation per request, got {allocations} over 1000 requests"
+    );
+}

--- a/crates/bolt-websocket/src/handler.rs
+++ b/crates/bolt-websocket/src/handler.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use std::collections::HashMap;
 
 use bolt_core::metadata::CorsConfig;
-use bolt_core::middleware::rate_limit::check_rate_limit;
+use bolt_core::middleware::rate_limit::{check_after_auth, check_before_auth};
 use bolt_core::state::{AppState, ROUTE_METADATA};
 use bolt_core::type_coercion::coerced_value_to_py;
 use bolt_core::type_coercion::{coerce_param, CoerceError, TYPE_STRING};
@@ -502,20 +502,20 @@ pub async fn handle_websocket_upgrade_with_handler(
         }
     }
 
-    // Check rate limiting BEFORE origin validation (reuse HTTP rate limit)
+    // Check rate limiting BEFORE origin validation (reuse HTTP rate limit).
+    // Address and header keys run here; identity keys run after auth below.
+    let mut client_ip = None;
     if let Some(route_metadata) = ROUTE_METADATA.get() {
         if let Some(route_meta) = route_metadata.get(handler_id) {
             if let Some(ref rate_config) = route_meta.rate_limit_config {
-                let client_ip = (rate_config.key == bolt_core::metadata::RateLimitKey::Ip)
-                    .then(|| {
-                        bolt_core::middleware::client_ip::resolve_from_headers(
-                            req.headers(),
-                            req.peer_addr().map(|address| address.ip()),
-                            &state.trusted_proxies,
-                        )
-                    })
-                    .flatten();
-                if let Some(response) = check_rate_limit(
+                if !matches!(rate_config.key, bolt_core::metadata::RateLimitKey::Header(_)) {
+                    client_ip = bolt_core::middleware::client_ip::resolve_from_headers(
+                        req.headers(),
+                        req.peer_addr().map(|address| address.ip()),
+                        &state.trusted_proxies,
+                    );
+                }
+                if let Some(response) = check_before_auth(
                     handler_id,
                     &headers,
                     client_ip.as_ref(),
@@ -542,8 +542,20 @@ pub async fn handle_websocket_upgrade_with_handler(
         if let Some(route_meta) = route_metadata.get(handler_id) {
             match validate_auth_and_guards(&headers, &route_meta.auth_backends, &route_meta.guards)
             {
-                AuthGuardResult::Allow(_ctx) => {
-                    // Guards passed, continue with WebSocket upgrade
+                AuthGuardResult::Allow(ctx) => {
+                    if let Some(ref rate_config) = route_meta.rate_limit_config {
+                        if let Some(response) = check_after_auth(
+                            handler_id,
+                            &headers,
+                            client_ip.as_ref(),
+                            ctx.as_ref(),
+                            rate_config,
+                            req.method().as_str(),
+                            req.path(),
+                        ) {
+                            return Ok(response);
+                        }
+                    }
                 }
                 AuthGuardResult::Unauthorized => {
                     return Ok(bolt_core::responses::error_401());

--- a/crates/bolt-websocket/src/handler.rs
+++ b/crates/bolt-websocket/src/handler.rs
@@ -508,7 +508,10 @@ pub async fn handle_websocket_upgrade_with_handler(
     if let Some(route_metadata) = ROUTE_METADATA.get() {
         if let Some(route_meta) = route_metadata.get(handler_id) {
             if let Some(ref rate_config) = route_meta.rate_limit_config {
-                if !matches!(rate_config.key, bolt_core::metadata::RateLimitKey::Header(_)) {
+                if !matches!(
+                    rate_config.key,
+                    bolt_core::metadata::RateLimitKey::Header(_)
+                ) {
                     client_ip = bolt_core::middleware::client_ip::resolve_from_headers(
                         req.headers(),
                         req.peer_addr().map(|address| address.ip()),

--- a/docs/src/topics/middleware.md
+++ b/docs/src/topics/middleware.md
@@ -77,7 +77,8 @@ Parameters:
 ### Counting per caller
 
 `key="ip"` counts per client address. A header name counts per header value.
-Callers that do not send the header share one bucket.
+Callers that do not send the header share one bucket. Bolt hashes the value,
+so its length is not limited.
 
 `key="user"` counts per authenticated identity. `key="api_key"` counts per
 authenticated API key. Both run after authentication:

--- a/docs/src/topics/middleware.md
+++ b/docs/src/topics/middleware.md
@@ -72,7 +72,27 @@ Parameters:
 
 - `rps` - Requests per second allowed
 - `burst` - Maximum burst size (allows short spikes)
-- `key` - What to count per (`"ip"` by default)
+- `key` - What to count per: `"ip"` (the default), `"user"`, `"api_key"` or a request header name
+
+### Counting per caller
+
+`key="ip"` counts per client address. A header name counts per header value.
+Callers that do not send the header share one bucket.
+
+`key="user"` counts per authenticated identity. `key="api_key"` counts per
+authenticated API key. Both run after authentication:
+
+```python
+@api.get("/api/data", auth=[JWTAuthentication()])
+@rate_limit(rps=10, key="user")
+async def data():
+    return {"data": []}
+```
+
+A caller with no identity is counted per client address. A guard such as
+`IsAuthenticated` rejects that caller before the limit is counted. Both keys
+need an auth backend on the route or the API. Without one, the server does
+not start.
 
 ### Client address behind a proxy
 

--- a/python/django_bolt/middleware/middleware.py
+++ b/python/django_bolt/middleware/middleware.py
@@ -408,6 +408,11 @@ def rate_limit(rps: int = 100, burst: int | None = None, key: str = "ip"):
     that is not a listed proxy. Without the setting, every caller behind the
     proxy shares one bucket.
 
+    `key="user"` counts per authenticated identity and `key="api_key"` counts
+    per authenticated API key. Both run after authentication. A caller with no
+    identity is counted per client address. Both need an auth backend on the
+    route or the API; the server refuses to start without one.
+
     Args:
         rps: Requests per second limit
         burst: Burst capacity (defaults to 2x rps)

--- a/python/tests/integration/apps/rate_limit_identity.py
+++ b/python/tests/integration/apps/rate_limit_identity.py
@@ -10,7 +10,9 @@ api = BoltAPI()
 
 BURST = 4
 SECRET = "rate-limit-identity-server-secret-32b"
-API_KEYS = {"key-a", "key-b"}
+# Distinctive on purpose: a test greps the server output for it.
+SECRET_API_KEY = "sk-live-DO-NOT-LOG-4f2b9c"
+API_KEYS = {"key-a", "key-b", SECRET_API_KEY}
 JWT = [JWTAuthentication(secret=SECRET)]
 KEY = [APIKeyAuthentication(api_keys=API_KEYS, header="x-api-key")]
 

--- a/python/tests/integration/apps/rate_limit_identity.py
+++ b/python/tests/integration/apps/rate_limit_identity.py
@@ -32,6 +32,15 @@ async def limited_by_user_guarded():
     return {"ok": True}
 
 
+# Keys on `api_key` but authenticates with JWT: a valid caller has no API-key
+# identity, so it shares the peer-address bucket with the rejected callers.
+# That makes a rejected request that still counted visible.
+@api.get("/limited-by-api-key-guarded", auth=JWT, guards=[IsAuthenticated()])
+@rate_limit(rps=1, burst=BURST, key="api_key")
+async def limited_by_api_key_guarded():
+    return {"ok": True}
+
+
 @api.get("/limited-by-api-key", auth=KEY)
 @rate_limit(rps=1, burst=BURST, key="api_key")
 async def limited_by_api_key():

--- a/python/tests/integration/apps/rate_limit_identity.py
+++ b/python/tests/integration/apps/rate_limit_identity.py
@@ -1,0 +1,23 @@
+"""App under test for identity-keyed rate limits on a real server."""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI
+from django_bolt.auth import APIKeyAuthentication
+from django_bolt.middleware import rate_limit
+
+api = BoltAPI()
+
+BURST = 4
+API_KEYS = {"key-a", "key-b"}
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/limited-by-api-key", auth=[APIKeyAuthentication(api_keys=API_KEYS, header="x-api-key")])
+@rate_limit(rps=1, burst=BURST, key="api_key")
+async def limited_by_api_key():
+    return {"ok": True}

--- a/python/tests/integration/apps/rate_limit_identity.py
+++ b/python/tests/integration/apps/rate_limit_identity.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from django_bolt import BoltAPI
-from django_bolt.auth import APIKeyAuthentication
+from django_bolt import BoltAPI, WebSocket
+from django_bolt.auth import APIKeyAuthentication, IsAuthenticated, JWTAuthentication
 from django_bolt.middleware import rate_limit
 
 api = BoltAPI()
 
 BURST = 4
+SECRET = "rate-limit-identity-server-secret-32b"
 API_KEYS = {"key-a", "key-b"}
+JWT = [JWTAuthentication(secret=SECRET)]
+KEY = [APIKeyAuthentication(api_keys=API_KEYS, header="x-api-key")]
 
 
 @api.get("/health")
@@ -17,7 +20,30 @@ async def health():
     return {"status": "ok"}
 
 
-@api.get("/limited-by-api-key", auth=[APIKeyAuthentication(api_keys=API_KEYS, header="x-api-key")])
+@api.get("/limited-by-user", auth=JWT)
+@rate_limit(rps=1, burst=BURST, key="user")
+async def limited_by_user():
+    return {"ok": True}
+
+
+@api.get("/limited-by-user-guarded", auth=JWT, guards=[IsAuthenticated()])
+@rate_limit(rps=1, burst=BURST, key="user")
+async def limited_by_user_guarded():
+    return {"ok": True}
+
+
+@api.get("/limited-by-api-key", auth=KEY)
 @rate_limit(rps=1, burst=BURST, key="api_key")
 async def limited_by_api_key():
     return {"ok": True}
+
+
+@api.websocket("/ws/limited-by-api-key", auth=KEY)
+@rate_limit(rps=1, burst=BURST, key="api_key")
+async def ws_limited_by_api_key(websocket: WebSocket):
+    await websocket.accept()
+    await websocket.send_text("connected")
+    # The client closes. A server-side close right after send_text can
+    # overtake the text frame on the wire.
+    async for _ in websocket.iter_text():
+        pass

--- a/python/tests/integration/apps/rate_limit_identity_no_auth.py
+++ b/python/tests/integration/apps/rate_limit_identity_no_auth.py
@@ -1,0 +1,22 @@
+"""App under test for an identity-keyed rate limit with no auth backend.
+
+The module imports. The server must refuse to start.
+"""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI
+from django_bolt.middleware import rate_limit
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/limited-by-user")
+@rate_limit(rps=1, burst=4, key="user")
+async def limited_by_user():
+    return {"ok": True}

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -708,6 +708,61 @@ def create_server_project(
     return project
 
 
+def attempt_ws_upgrade(
+    host: str, port: int, path: str, *, headers: dict[str, str] | None = None, timeout: float = 5.0
+) -> tuple[str, str]:
+    """Send a raw WebSocket upgrade request and return (status_line, body_text).
+
+    Unlike `SimpleWebSocketClient`, this captures the full response (including
+    the error body) so a *rejected* upgrade can be inspected rather than
+    asserting a 101 handshake.
+    """
+    key = base64.b64encode(secrets.token_bytes(16)).decode()
+    request = "\r\n".join(
+        [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}:{port}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key}",
+            "Sec-WebSocket-Version: 13",
+            *(f"{name}: {value}" for name, value in (headers or {}).items()),
+            "",
+            "",
+        ]
+    )
+
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        sock.sendall(request.encode("utf-8"))
+
+        buf = bytearray()
+        while b"\r\n\r\n" not in buf:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+
+        header_part, _, body_part = bytes(buf).partition(b"\r\n\r\n")
+        header_text = header_part.decode("utf-8", errors="replace")
+
+        content_length = 0
+        for line in header_text.splitlines()[1:]:
+            if line.lower().startswith("content-length:"):
+                content_length = int(line.split(":", 1)[1].strip())
+                break
+
+        body = bytearray(body_part)
+        while len(body) < content_length:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            body.extend(chunk)
+
+    status_line = header_text.splitlines()[0] if header_text else ""
+    return status_line, body.decode("utf-8", errors="replace")
+
+
 class SimpleWebSocketClient:
     def __init__(
         self,

--- a/python/tests/integration/test_rate_limit_client_ip_server_integration.py
+++ b/python/tests/integration/test_rate_limit_client_ip_server_integration.py
@@ -88,16 +88,20 @@ def test_a_header_key_buckets_on_the_header_value(make_server_project):
         # The header route and the address route keep separate buckets.
         by_ip = server.request("GET", "/limited")
 
-        too_long = server.request("GET", "/limited-by-header", headers={"X-Tenant": "t" * 257})
-        longest_allowed = server.request("GET", "/limited-by-header", headers={"X-Tenant": "u" * 256})
+        # A long value is hashed like any other, so nothing caps its length.
+        # `key="authorization"` with a JWT lands here.
+        long_value = server.request("GET", "/limited-by-header", headers={"X-Tenant": "t" * 4096})
+        other_long_value = server.request(
+            "GET", "/limited-by-header", headers={"X-Tenant": "u" * 4096}
+        )
 
     assert other_tenant.status_code == 200, other_tenant.text
     assert same_tenant.status_code == 429, same_tenant.text
     assert missing_again.status_code == 429, missing_again.text
     assert by_ip.status_code == 200, by_ip.text
-    assert too_long.status_code == 400, too_long.text
-    assert too_long.json() == {"detail": "Rate limit key too long"}
-    assert longest_allowed.status_code == 200, longest_allowed.text
+    # Two long values, two buckets. Neither is rejected for its length.
+    assert long_value.status_code == 200, long_value.text
+    assert other_long_value.status_code == 200, other_long_value.text
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/integration/test_rate_limit_client_ip_server_integration.py
+++ b/python/tests/integration/test_rate_limit_client_ip_server_integration.py
@@ -91,9 +91,7 @@ def test_a_header_key_buckets_on_the_header_value(make_server_project):
         # A long value is hashed like any other, so nothing caps its length.
         # `key="authorization"` with a JWT lands here.
         long_value = server.request("GET", "/limited-by-header", headers={"X-Tenant": "t" * 4096})
-        other_long_value = server.request(
-            "GET", "/limited-by-header", headers={"X-Tenant": "u" * 4096}
-        )
+        other_long_value = server.request("GET", "/limited-by-header", headers={"X-Tenant": "u" * 4096})
 
     assert other_tenant.status_code == 200, other_tenant.text
     assert same_tenant.status_code == 429, same_tenant.text

--- a/python/tests/integration/test_rate_limit_identity_server_integration.py
+++ b/python/tests/integration/test_rate_limit_identity_server_integration.py
@@ -1,0 +1,36 @@
+"""Real-server test for `@rate_limit(key="api_key")`.
+
+The identity check runs after authentication inside the production `runbolt`
+dispatch. `TestClient` exercises the same Rust functions through a separate
+entry point, so one test confirms the server wiring over real TCP.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .apps import app_module
+from .apps.rate_limit_identity import BURST
+
+pytestmark = pytest.mark.server_integration
+
+APP = app_module("rate_limit_identity")
+
+
+def _statuses(server, n, **headers):
+    return [server.request("GET", "/limited-by-api-key", headers=headers).status_code for _ in range(n)]
+
+
+def test_each_api_key_gets_its_own_bucket_and_unknown_keys_share_the_peer(make_server_project):
+    project = make_server_project(api_module=APP)
+
+    with project.start() as server:
+        assert _statuses(server, BURST, **{"X-API-Key": "key-a"}) == [200] * BURST
+        assert _statuses(server, BURST, **{"X-API-Key": "key-b"}) == [200] * BURST
+        assert _statuses(server, 1, **{"X-API-Key": "key-a"}) == [429]
+        # Unknown keys have no identity. They share the peer-address bucket.
+        bogus = [
+            server.request("GET", "/limited-by-api-key", headers={"X-API-Key": f"no-{i}"}).status_code
+            for i in range(BURST + 1)
+        ]
+        assert bogus == [200] * BURST + [429]

--- a/python/tests/integration/test_rate_limit_identity_server_integration.py
+++ b/python/tests/integration/test_rate_limit_identity_server_integration.py
@@ -15,7 +15,7 @@ from django.contrib.auth import get_user_model
 from django_bolt.auth import create_jwt_for_user
 
 from .apps import app_module
-from .apps.rate_limit_identity import BURST, SECRET
+from .apps.rate_limit_identity import BURST, SECRET, SECRET_API_KEY
 from .helpers import attempt_ws_upgrade
 
 pytestmark = pytest.mark.server_integration
@@ -124,3 +124,23 @@ def test_identity_key_without_auth_aborts_startup(make_server_project):
     with pytest.raises(AssertionError) as excinfo, project.start(timeout=15):
         pass
     assert 'key="user"' in str(excinfo.value)
+
+
+def test_the_rejection_log_does_not_carry_the_api_key(make_server_project):
+    """A 429 must not write the caller's credential to the server output.
+
+    `AuthContext::from_api_key` stores `apikey:<raw key>` in `user_id`, which
+    is what an `api_key` bucket counts on.
+    """
+    project = make_server_project(api_module=APP)
+
+    with project.start() as server:
+        statuses = _statuses(server, "/limited-by-api-key", BURST + 2, {"X-API-Key": SECRET_API_KEY})
+
+    stdout, stderr = server.stop()
+    output = stdout + stderr
+
+    assert statuses[-1] == 429, statuses
+    # Without this the test passes when the log line never ran at all.
+    assert "Rate limit exceeded" in output, output[-2000:]
+    assert SECRET_API_KEY not in output, "the raw API key reached the server output"

--- a/python/tests/integration/test_rate_limit_identity_server_integration.py
+++ b/python/tests/integration/test_rate_limit_identity_server_integration.py
@@ -57,10 +57,25 @@ def test_unauthenticated_callers_share_the_peer_bucket(make_server_project):
 
 
 def test_guard_rejects_before_the_bucket_is_counted(make_server_project):
-    """A 401 spends nothing, for the peer or for the user that authenticates later."""
+    """A 401 spends nothing from the bucket it would have been counted in.
+
+    `/limited-by-api-key-guarded` keys on `api_key` but authenticates with
+    JWT, so the valid caller has no API-key identity and shares the
+    peer-address bucket with the rejected callers. On `/limited-by-user-guarded`
+    the two use different buckets, so it only shows that a 401 comes first.
+    """
     project = make_server_project(api_module=APP)
 
     with project.start() as server:
+        path = "/limited-by-api-key-guarded"
+        assert _statuses(server, path, BURST + 2) == [401] * (BURST + 2)
+        # Same bucket as the rejected calls above. Full burst means they left
+        # it untouched.
+        assert _statuses(server, path, BURST, _bearer("alice")) == [200] * BURST
+        # Spent now, which confirms the caller really was counted in that
+        # bucket rather than in one of its own.
+        assert _statuses(server, path, 1, _bearer("bob")) == [429]
+
         assert _statuses(server, "/limited-by-user-guarded", BURST + 2) == [401] * (BURST + 2)
         assert _statuses(server, "/limited-by-user-guarded", BURST, _bearer("alice")) == [200] * BURST
         assert _statuses(server, "/limited-by-user-guarded", 1, _bearer("alice")) == [429]

--- a/python/tests/integration/test_rate_limit_identity_server_integration.py
+++ b/python/tests/integration/test_rate_limit_identity_server_integration.py
@@ -1,36 +1,111 @@
-"""Real-server test for `@rate_limit(key="api_key")`.
+"""Real-server tests for `@rate_limit(key="user")` and `key="api_key"`.
 
-The identity check runs after authentication inside the production `runbolt`
-dispatch. `TestClient` exercises the same Rust functions through a separate
-entry point, so one test confirms the server wiring over real TCP.
+The identity check runs after authentication in the production `runbolt`
+HTTP dispatch and in the WebSocket upgrade. `TestClient` reaches the same
+Rust functions through a separate entry point, so these tests confirm the
+server wiring over real TCP. Tokens come from the public
+`create_jwt_for_user()` API.
 """
 
 from __future__ import annotations
 
 import pytest
+from django.contrib.auth import get_user_model
+
+from django_bolt.auth import create_jwt_for_user
 
 from .apps import app_module
-from .apps.rate_limit_identity import BURST
+from .apps.rate_limit_identity import BURST, SECRET
+from .helpers import attempt_ws_upgrade
 
 pytestmark = pytest.mark.server_integration
 
 APP = app_module("rate_limit_identity")
 
 
-def _statuses(server, n, **headers):
-    return [server.request("GET", "/limited-by-api-key", headers=headers).status_code for _ in range(n)]
+def _bearer(username: str) -> dict[str, str]:
+    # Unsaved model instance: the server verifies the signature and `sub`
+    # claim only. No database access is needed on either side.
+    user = get_user_model()(id=abs(hash(username)) % 100_000 + 1, username=username)
+    return {"Authorization": f"Bearer {create_jwt_for_user(user, secret=SECRET)}"}
+
+
+def _statuses(server, path, n, headers=None):
+    return [server.request("GET", path, headers=headers or {}).status_code for _ in range(n)]
+
+
+def test_each_user_gets_its_own_bucket(make_server_project):
+    project = make_server_project(api_module=APP)
+
+    with project.start() as server:
+        for name in ("alice", "bob", "carol"):
+            assert _statuses(server, "/limited-by-user", BURST, _bearer(name)) == [200] * BURST
+        assert _statuses(server, "/limited-by-user", 1, _bearer("alice")) == [429]
+        # A new user is not affected by the exhausted buckets.
+        assert _statuses(server, "/limited-by-user", 1, _bearer("dave")) == [200]
+
+
+def test_unauthenticated_callers_share_the_peer_bucket(make_server_project):
+    """No identity: the peer address is the bucket. A valid user is untouched."""
+    project = make_server_project(api_module=APP)
+
+    with project.start() as server:
+        assert _statuses(server, "/limited-by-user", BURST + 1) == [200] * BURST + [429]
+        # A bad token is not an identity either and lands in the same bucket.
+        assert _statuses(server, "/limited-by-user", 1, {"Authorization": "Bearer not-a-jwt"}) == [429]
+        assert _statuses(server, "/limited-by-user", BURST, _bearer("alice")) == [200] * BURST
+
+
+def test_guard_rejects_before_the_bucket_is_counted(make_server_project):
+    """A 401 spends nothing, for the peer or for the user that authenticates later."""
+    project = make_server_project(api_module=APP)
+
+    with project.start() as server:
+        assert _statuses(server, "/limited-by-user-guarded", BURST + 2) == [401] * (BURST + 2)
+        assert _statuses(server, "/limited-by-user-guarded", BURST, _bearer("alice")) == [200] * BURST
+        assert _statuses(server, "/limited-by-user-guarded", 1, _bearer("alice")) == [429]
 
 
 def test_each_api_key_gets_its_own_bucket_and_unknown_keys_share_the_peer(make_server_project):
     project = make_server_project(api_module=APP)
 
     with project.start() as server:
-        assert _statuses(server, BURST, **{"X-API-Key": "key-a"}) == [200] * BURST
-        assert _statuses(server, BURST, **{"X-API-Key": "key-b"}) == [200] * BURST
-        assert _statuses(server, 1, **{"X-API-Key": "key-a"}) == [429]
-        # Unknown keys have no identity. They share the peer-address bucket.
+        assert _statuses(server, "/limited-by-api-key", BURST, {"X-API-Key": "key-a"}) == [200] * BURST
+        assert _statuses(server, "/limited-by-api-key", BURST, {"X-API-Key": "key-b"}) == [200] * BURST
+        assert _statuses(server, "/limited-by-api-key", 1, {"X-API-Key": "key-a"}) == [429]
+        # Unknown keys have no identity. They share the peer-address bucket, so
+        # a caller cannot buy a fresh bucket per request by changing the key.
         bogus = [
             server.request("GET", "/limited-by-api-key", headers={"X-API-Key": f"no-{i}"}).status_code
             for i in range(BURST + 1)
         ]
         assert bogus == [200] * BURST + [429]
+
+
+def test_websocket_upgrade_is_limited_per_api_key(make_server_project):
+    """The production upgrade path runs the identity check after auth.
+
+    Only the handshake status matters here: 101 for an allowed upgrade, 429
+    for a spent bucket.
+    """
+    project = make_server_project(api_module=APP)
+
+    def status(key: str) -> str:
+        line, _ = attempt_ws_upgrade(server.host, server.port, "/ws/limited-by-api-key", headers={"X-API-Key": key})
+        return line.split(" ", 2)[1]
+
+    with project.start() as server:
+        assert [status("key-a") for _ in range(BURST)] == ["101"] * BURST
+        assert [status("key-b") for _ in range(BURST)] == ["101"] * BURST
+        assert status("key-a") == "429"
+        # Unknown keys share the peer bucket.
+        assert [status(f"no-{i}") for i in range(BURST + 1)] == ["101"] * BURST + ["429"]
+
+
+def test_identity_key_without_auth_aborts_startup(make_server_project):
+    """No backend can ever give an identity, so the server must not boot."""
+    project = make_server_project(api_module=app_module("rate_limit_identity_no_auth"))
+
+    with pytest.raises(AssertionError) as excinfo, project.start(timeout=15):
+        pass
+    assert 'key="user"' in str(excinfo.value)

--- a/python/tests/integration/test_websocket_param_length_server_integration.py
+++ b/python/tests/integration/test_websocket_param_length_server_integration.py
@@ -10,68 +10,12 @@ of passing the raw string through to Python.
 
 from __future__ import annotations
 
-import base64
-import secrets
-import socket
-
 import pytest
 
 from .apps import app_module
-from .helpers import SimpleWebSocketClient
+from .helpers import SimpleWebSocketClient, attempt_ws_upgrade
 
 pytestmark = pytest.mark.server_integration
-
-
-def _attempt_ws_upgrade(host: str, port: int, path: str, *, timeout: float = 5.0) -> tuple[str, str]:
-    """Send a raw WebSocket upgrade request and return (status_line, body_text).
-
-    Unlike `SimpleWebSocketClient`, this captures the full response (including
-    the error body) so a *rejected* upgrade can be inspected rather than
-    asserting a 101 handshake.
-    """
-    key = base64.b64encode(secrets.token_bytes(16)).decode()
-    request = "\r\n".join(
-        [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}:{port}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {key}",
-            "Sec-WebSocket-Version: 13",
-            "",
-            "",
-        ]
-    )
-
-    with socket.create_connection((host, port), timeout=timeout) as sock:
-        sock.settimeout(timeout)
-        sock.sendall(request.encode("utf-8"))
-
-        buf = bytearray()
-        while b"\r\n\r\n" not in buf:
-            chunk = sock.recv(4096)
-            if not chunk:
-                break
-            buf.extend(chunk)
-
-        header_part, _, body_part = bytes(buf).partition(b"\r\n\r\n")
-        header_text = header_part.decode("utf-8", errors="replace")
-
-        content_length = 0
-        for line in header_text.splitlines()[1:]:
-            if line.lower().startswith("content-length:"):
-                content_length = int(line.split(":", 1)[1].strip())
-                break
-
-        body = bytearray(body_part)
-        while len(body) < content_length:
-            chunk = sock.recv(4096)
-            if not chunk:
-                break
-            body.extend(chunk)
-
-    status_line = header_text.splitlines()[0] if header_text else ""
-    return status_line, body.decode("utf-8", errors="replace")
 
 
 def _make_ws_project(make_server_project):
@@ -84,7 +28,7 @@ def test_websocket_oversized_path_param_rejects_upgrade(make_server_project):
     oversized = "a" * 9000  # exceeds the default 8192-byte limit
 
     with project.start() as server:
-        status_line, body = _attempt_ws_upgrade(server.host, server.port, f"/ws/path/{oversized}")
+        status_line, body = attempt_ws_upgrade(server.host, server.port, f"/ws/path/{oversized}")
 
     assert "400" in status_line, f"Expected 400 rejection, got status={status_line!r} body={body!r}"
     assert "Parameter too long" in body, f"body={body!r}"
@@ -96,7 +40,7 @@ def test_websocket_oversized_query_param_rejects_upgrade(make_server_project):
     oversized = "a" * 9000
 
     with project.start() as server:
-        status_line, body = _attempt_ws_upgrade(server.host, server.port, f"/ws/plain?value={oversized}")
+        status_line, body = attempt_ws_upgrade(server.host, server.port, f"/ws/plain?value={oversized}")
 
     assert "400" in status_line, f"Expected 400 rejection, got status={status_line!r} body={body!r}"
     assert "Parameter too long" in body, f"body={body!r}"
@@ -126,7 +70,7 @@ def test_websocket_honors_django_bolt_max_param_length_env(make_server_project):
     rejected = "a" * 16385  # over the configured 16384
 
     with project.start(env={"DJANGO_BOLT_MAX_PARAM_LENGTH": "16384"}) as server:
-        status_line, body = _attempt_ws_upgrade(server.host, server.port, f"/ws/path/{rejected}")
+        status_line, body = attempt_ws_upgrade(server.host, server.port, f"/ws/path/{rejected}")
         assert "400" in status_line, f"Expected 400 rejection, got status={status_line!r} body={body!r}"
         assert "Parameter too long" in body, f"body={body!r}"
 

--- a/python/tests/test_rate_limit_identity_keys.py
+++ b/python/tests/test_rate_limit_identity_keys.py
@@ -1,0 +1,119 @@
+"""
+`@rate_limit(key="user")` and `key="api_key"` count per authenticated identity.
+
+The check runs after authentication. A caller without an identity falls back
+to one bucket per client address. Tokens are minted with the public
+`create_jwt_for_user()` API. Refs #301.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from django_bolt import BoltAPI
+from django_bolt.auth import APIKeyAuthentication, IsAuthenticated, JWTAuthentication, create_jwt_for_user
+from django_bolt.middleware import rate_limit
+from django_bolt.testing import TestClient
+
+SECRET = "rate-limit-identity-secret"
+BURST = 3
+
+# Limiters live in one process-wide map keyed by (handler id, quota, bucket).
+# Every `BoltAPI` numbers handlers from 0, so a fresh app with the same quota
+# would inherit the last test's buckets. A distinct `rps` per app keeps the
+# same `BURST` and isolates the tests.
+_rps = itertools.count(1)
+
+
+def bearer(user) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_jwt_for_user(user, secret=SECRET)}"}
+
+
+def _make_api(key: str, auth, guards=()):
+    api = BoltAPI()
+
+    @api.get("/limited", auth=auth, guards=list(guards))
+    @rate_limit(rps=next(_rps), burst=BURST, key=key)
+    async def limited():
+        return {"ok": True}
+
+    return api
+
+
+def _statuses(client, n: int, **kwargs) -> list[int]:
+    return [client.get("/limited", **kwargs).status_code for _ in range(n)]
+
+
+@pytest.fixture
+def users(db):
+    model = get_user_model()
+    return [model.objects.create(username=f"u{i}") for i in range(3)]
+
+
+@pytest.mark.django_db
+def test_user_key_gives_each_user_its_own_bucket(users):
+    with TestClient(_make_api("user", [JWTAuthentication(secret=SECRET)])) as client:
+        for user in users:
+            assert _statuses(client, BURST, headers=bearer(user)) == [200] * BURST
+        assert client.get("/limited", headers=bearer(users[0])).status_code == 429
+
+
+@pytest.mark.django_db
+def test_user_key_still_limits_one_user(users):
+    with TestClient(_make_api("user", [JWTAuthentication(secret=SECRET)])) as client:
+        assert _statuses(client, BURST + 2, headers=bearer(users[0])) == [200] * BURST + [429, 429]
+
+
+@pytest.mark.django_db
+def test_user_key_unauthenticated_callers_share_an_ip_bucket(users):
+    """No identity: limit per client address, and do not touch any user's bucket."""
+    with TestClient(_make_api("user", [JWTAuthentication(secret=SECRET)])) as client:
+        assert _statuses(client, BURST + 1) == [200] * BURST + [429]
+        assert _statuses(client, BURST, headers=bearer(users[0])) == [200] * BURST
+
+
+@pytest.mark.django_db
+def test_user_key_with_guard_rejects_before_counting(users):
+    """A 401 is not a spent token for the user that later authenticates."""
+    api = _make_api("user", [JWTAuthentication(secret=SECRET)], guards=[IsAuthenticated()])
+    with TestClient(api) as client:
+        assert _statuses(client, BURST + 1) == [401] * (BURST + 1)
+        assert _statuses(client, BURST, headers=bearer(users[0])) == [200] * BURST
+
+
+def test_api_key_gives_each_key_its_own_bucket():
+    auth = [APIKeyAuthentication(api_keys={"key-a", "key-b"}, header="x-api-key")]
+    with TestClient(_make_api("api_key", auth)) as client:
+        assert _statuses(client, BURST, headers={"X-API-Key": "key-a"}) == [200] * BURST
+        assert _statuses(client, BURST, headers={"X-API-Key": "key-b"}) == [200] * BURST
+        assert client.get("/limited", headers={"X-API-Key": "key-a"}).status_code == 429
+
+
+def test_api_key_unknown_key_falls_back_to_ip_bucket():
+    """An invalid key has no identity; it cannot pick a fresh bucket per value."""
+    auth = [APIKeyAuthentication(api_keys={"key-a"}, header="x-api-key")]
+    with TestClient(_make_api("api_key", auth)) as client:
+        statuses = [client.get("/limited", headers={"X-API-Key": f"bogus-{i}"}).status_code for i in range(BURST + 1)]
+        assert statuses == [200] * BURST + [429]
+
+
+@pytest.mark.django_db
+def test_api_key_ignores_jwt_identity(users):
+    """`key="api_key"` counts API keys only. A JWT caller is limited by address."""
+    auth = [JWTAuthentication(secret=SECRET), APIKeyAuthentication(api_keys={"key-a"}, header="x-api-key")]
+    with TestClient(_make_api("api_key", auth)) as client:
+        statuses = [client.get("/limited", headers=bearer(u)).status_code for u in users] + [
+            client.get("/limited", headers=bearer(users[0])).status_code
+        ]
+        assert statuses == [200] * BURST + [429]
+        assert _statuses(client, BURST, headers={"X-API-Key": "key-a"}) == [200] * BURST
+
+
+@pytest.mark.parametrize("key", ["user", "api_key"])
+def test_identity_key_without_auth_fails_at_startup(key):
+    """No backend can ever produce an identity, so the route must not start."""
+    with pytest.raises(ValueError, match=f'key="{key}"'):
+        TestClient(_make_api(key, None))

--- a/python/tests/test_rate_limit_identity_keys.py
+++ b/python/tests/test_rate_limit_identity_keys.py
@@ -13,10 +13,10 @@ import itertools
 import pytest
 from django.contrib.auth import get_user_model
 
-from django_bolt import BoltAPI
+from django_bolt import BoltAPI, WebSocket
 from django_bolt.auth import APIKeyAuthentication, IsAuthenticated, JWTAuthentication, create_jwt_for_user
 from django_bolt.middleware import rate_limit
-from django_bolt.testing import TestClient
+from django_bolt.testing import TestClient, WebSocketTestClient
 
 SECRET = "rate-limit-identity-secret"
 BURST = 3
@@ -76,12 +76,20 @@ def test_user_key_unauthenticated_callers_share_an_ip_bucket(users):
 
 
 @pytest.mark.django_db
-def test_user_key_with_guard_rejects_before_counting(users):
-    """A 401 is not a spent token for the user that later authenticates."""
-    api = _make_api("user", [JWTAuthentication(secret=SECRET)], guards=[IsAuthenticated()])
+def test_guard_rejects_before_counting_on_the_shared_bucket(users):
+    """A rejected request spends nothing from the bucket it would have used.
+
+    The route keys on `api_key` but authenticates with JWT, so a valid caller
+    has no API-key identity and lands in the same no-identity bucket as the
+    rejected callers. A 401 that still counted would show up here.
+    """
+    api = _make_api("api_key", [JWTAuthentication(secret=SECRET)], guards=[IsAuthenticated()])
     with TestClient(api) as client:
-        assert _statuses(client, BURST + 1) == [401] * (BURST + 1)
+        assert _statuses(client, BURST + 2) == [401] * (BURST + 2)
         assert _statuses(client, BURST, headers=bearer(users[0])) == [200] * BURST
+        # The bucket is spent now, which proves the caller really was counted
+        # in it — so the earlier 401s shared it and left it untouched.
+        assert _statuses(client, 1, headers=bearer(users[1])) == [429]
 
 
 def test_api_key_gives_each_key_its_own_bucket():
@@ -117,3 +125,40 @@ def test_identity_key_without_auth_fails_at_startup(key):
     """No backend can ever produce an identity, so the route must not start."""
     with pytest.raises(ValueError, match=f'key="{key}"'):
         TestClient(_make_api(key, None))
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_websocket_guard_rejects_before_counting_on_the_shared_bucket(users):
+    """The WebSocket backend counts the bucket only after guards pass.
+
+    Same shape as the HTTP test: `api_key` key with JWT authentication, so
+    the rejected and the accepted caller share the no-identity bucket. A
+    rejected upgrade that still counted would exhaust it and turn a later
+    rejection into "Rate limit exceeded".
+    """
+    api = BoltAPI()
+
+    @api.websocket("/ws/limited", auth=[JWTAuthentication(secret=SECRET)], guards=[IsAuthenticated()])
+    @rate_limit(rps=next(_rps), burst=BURST, key="api_key")
+    async def limited(websocket: WebSocket):
+        await websocket.accept()
+        await websocket.send_text("connected")
+
+    async def connect(headers=None):
+        async with WebSocketTestClient(
+            api, "/ws/limited", headers=headers, cors_allowed_origins=["*"], read_django_settings=False
+        ) as websocket:
+            return await websocket.receive_text()
+
+    for _ in range(BURST + 2):
+        with pytest.raises(PermissionError) as excinfo:
+            await connect()
+        assert "Authentication required" in str(excinfo.value)
+
+    for _ in range(BURST):
+        assert await connect(bearer(users[0])) == "connected"
+
+    with pytest.raises(PermissionError) as excinfo:
+        await connect(bearer(users[1]))
+    assert "Rate limit exceeded" in str(excinfo.value)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -890,24 +890,25 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
         None
     };
 
-    // Process rate limiting (Rust-native, no GIL)
-    if let Some(route_meta) = route_metadata {
-        if let Some(ref rate_config) = route_meta.rate_limit_config {
-            if let Some(headers_map) = headers.as_ref() {
-                if let Some(response) = middleware::rate_limit::check_rate_limit(
-                    handler_id,
-                    headers_map,
-                    client_ip.as_ref(),
-                    rate_config,
-                    &method,
-                    &path,
-                ) {
-                    // CORS headers will be added by CorsMiddleware
-                    return response;
-                }
-            } else {
-                debug_assert!(false, "rate-limited route missing extracted headers");
+    // Rate limiting (Rust-native, no GIL). Address and header keys run before
+    // authentication so a flood never pays for token verification. Identity
+    // keys run after it; see the second call below.
+    let rate_config = route_metadata.and_then(|m| m.rate_limit_config.as_ref());
+    if let Some(config) = rate_config {
+        if let Some(headers_map) = headers.as_ref() {
+            if let Some(response) = middleware::rate_limit::check_before_auth(
+                handler_id,
+                headers_map,
+                client_ip.as_ref(),
+                config,
+                &method,
+                &path,
+            ) {
+                // CORS headers will be added by CorsMiddleware
+                return response;
             }
+        } else {
+            debug_assert!(false, "rate-limited route missing extracted headers");
         }
     }
 
@@ -951,6 +952,23 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
     } else {
         None
     };
+
+    if let Some(config) = rate_config {
+        if let Some(headers_map) = headers.as_ref() {
+            if let Some(response) = middleware::rate_limit::check_after_auth(
+                handler_id,
+                headers_map,
+                client_ip.as_ref(),
+                auth_ctx.as_ref(),
+                config,
+                &method,
+                &path,
+            ) {
+                // CORS headers will be added by CorsMiddleware
+                return response;
+            }
+        }
+    }
 
     // Optimization: Only parse cookies if handler needs them
     // Cookie parsing can be expensive for requests with many cookies

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -891,19 +891,18 @@ async fn handle_test_request_internal(
     let conn_scheme = conn_info.scheme().to_owned();
     let conn_remote_addr = client_ip;
 
-    // Rate limiting
-    if let Some(ref meta) = route_meta {
-        if let Some(ref rate_config) = meta.rate_limit_config {
-            if let Some(response) = middleware::rate_limit::check_rate_limit(
-                handler_id,
-                &headers,
-                client_ip.as_ref(),
-                rate_config,
-                method,
-                path,
-            ) {
-                return response;
-            }
+    // Rate limiting: address and header keys before auth, identity keys after.
+    let rate_config = route_meta.as_ref().and_then(|m| m.rate_limit_config.as_ref());
+    if let Some(rate_config) = rate_config {
+        if let Some(response) = middleware::rate_limit::check_before_auth(
+            handler_id,
+            &headers,
+            client_ip.as_ref(),
+            rate_config,
+            method,
+            path,
+        ) {
+            return response;
         }
     }
 
@@ -930,6 +929,20 @@ async fn handle_test_request_internal(
     } else {
         None
     };
+
+    if let Some(rate_config) = rate_config {
+        if let Some(response) = middleware::rate_limit::check_after_auth(
+            handler_id,
+            &headers,
+            client_ip.as_ref(),
+            auth_ctx.as_ref(),
+            rate_config,
+            method,
+            path,
+        ) {
+            return response;
+        }
+    }
 
     // Cookies
     let needs_cookies = route_meta
@@ -1330,10 +1343,12 @@ pub fn handle_test_websocket(
 
     let handler_id = route.handler_id;
     let handler = route.handler.clone_ref(py);
-    // Rate limiting for WebSocket
+    // Rate limiting for WebSocket: address and header keys before auth,
+    // identity keys after it.
+    let mut client_ip = None;
     if let Some(route_meta) = app.route_metadata.get(handler_id) {
         if let Some(ref rate_config) = route_meta.rate_limit_config {
-            let client_ip = (rate_config.key == RateLimitKey::Ip)
+            client_ip = (!matches!(rate_config.key, RateLimitKey::Header(_)))
                 .then(|| {
                     bolt_core::middleware::client_ip::resolve(
                         header_map
@@ -1348,7 +1363,7 @@ pub fn handle_test_websocket(
                     )
                 })
                 .flatten();
-            if bolt_core::middleware::rate_limit::check_rate_limit(
+            if bolt_core::middleware::rate_limit::check_before_auth(
                 handler_id,
                 &header_map,
                 client_ip.as_ref(),
@@ -1372,6 +1387,24 @@ pub fn handle_test_websocket(
         } else {
             None
         };
+
+        if let Some(rate_config) = route_meta.rate_limit_config.as_ref() {
+            if bolt_core::middleware::rate_limit::check_after_auth(
+                handler_id,
+                &header_map,
+                client_ip.as_ref(),
+                auth_ctx.as_ref(),
+                rate_config,
+                "GET",
+                &path,
+            )
+            .is_some()
+            {
+                return Err(pyo3::exceptions::PyPermissionError::new_err(
+                    "Rate limit exceeded",
+                ));
+            }
+        }
 
         if !route_meta.guards.is_empty() {
             match evaluate_guards(&route_meta.guards, auth_ctx.as_ref()) {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1388,24 +1388,6 @@ pub fn handle_test_websocket(
             None
         };
 
-        if let Some(rate_config) = route_meta.rate_limit_config.as_ref() {
-            if bolt_core::middleware::rate_limit::check_after_auth(
-                handler_id,
-                &header_map,
-                client_ip.as_ref(),
-                auth_ctx.as_ref(),
-                rate_config,
-                "GET",
-                &path,
-            )
-            .is_some()
-            {
-                return Err(pyo3::exceptions::PyPermissionError::new_err(
-                    "Rate limit exceeded",
-                ));
-            }
-        }
-
         if !route_meta.guards.is_empty() {
             match evaluate_guards(&route_meta.guards, auth_ctx.as_ref()) {
                 GuardResult::Allow => {}
@@ -1422,6 +1404,26 @@ pub fn handle_test_websocket(
                         ),
                     ));
                 }
+            }
+        }
+
+        // After guards, mirroring the production upgrade path: a rejected
+        // upgrade must not spend the bucket it would have been counted in.
+        if let Some(rate_config) = route_meta.rate_limit_config.as_ref() {
+            if bolt_core::middleware::rate_limit::check_after_auth(
+                handler_id,
+                &header_map,
+                client_ip.as_ref(),
+                auth_ctx.as_ref(),
+                rate_config,
+                "GET",
+                &path,
+            )
+            .is_some()
+            {
+                return Err(pyo3::exceptions::PyPermissionError::new_err(
+                    "Rate limit exceeded",
+                ));
             }
         }
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -892,7 +892,9 @@ async fn handle_test_request_internal(
     let conn_remote_addr = client_ip;
 
     // Rate limiting: address and header keys before auth, identity keys after.
-    let rate_config = route_meta.as_ref().and_then(|m| m.rate_limit_config.as_ref());
+    let rate_config = route_meta
+        .as_ref()
+        .and_then(|m| m.rate_limit_config.as_ref());
     if let Some(rate_config) = rate_config {
         if let Some(response) = middleware::rate_limit::check_before_auth(
             handler_id,


### PR DESCRIPTION
Refs #301. Replaces the reject-at-import approach in #310 with the real feature.

## What

`@rate_limit(key="user")` and `key="api_key"` were documented but never implemented. They fell into the header catch-all, matched no header, and resolved to one shared `"unknown"` bucket. A route marked "1 rps per user" was 1 rps in total.

Both keys now count per authenticated identity:

- `key="user"` — `AuthContext.user_id` from any backend.
- `key="api_key"` — the API key only. A JWT caller on an `api_key`-keyed route has no identity.
- A caller with no identity is counted per client address. This keeps an unauthenticated flood from picking a fresh bucket per request.
- A route with an identity key and no auth backend (route or API level) fails at startup.

## Ordering

`RateLimitKey::needs_identity()` splits the check into two phases in `bolt-core::middleware::rate_limit`:

- `check_before_auth` — `ip` and header keys, unchanged position. A flood never pays for token verification.
- `check_after_auth` — identity keys, with the `AuthContext`. A guard such as `IsAuthenticated` rejects before the bucket is counted.

All four call sites (HTTP dispatch, WebSocket upgrade, and both `TestClient` paths) use the two wrappers.

## Buckets key on a hash

A bucket key used to be stored as its own text, so every header-keyed and identity-keyed request allocated a `Box<str>` for the map key. The map now holds an 8-byte hash. `KeySource` borrows the key material, hashes it, and is formatted only when a request is rejected.

- The seed is a process-lived `ahash::RandomState`, so a caller cannot craft a value that lands in another caller's bucket. Buckets are per-process already, so the seed does not need to agree across workers.
- A leading tag keeps an address and an identity apart, because an identity-keyed route falls back between the two.
- Nothing is stored per key, so the 256-byte cap is gone with its `400 Rate limit key too long` response. `key="authorization"` with a JWT used to be refused and now counts like any other value.

**Measured:** a header-keyed request made 1000 allocations per 1000 requests before and makes 0 after (`crates/bolt-core/tests/rate_limit_allocations.rs`, a counting allocator, per `docs/PROFILING.md`). The RPS effect is below the noise floor of an HTTP benchmark on this hardware: across two sessions the unaffected `/plain` control route itself moved 10%, so the allocation count is the evidence, not a throughput number.

## Tests

- `python/tests/test_rate_limit_identity_keys.py` — 10 in-process tests: per-user buckets, per-key buckets, IP fallback, guard ordering (HTTP and WebSocket), JWT-on-`api_key` route, startup failure.
- `python/tests/integration/test_rate_limit_identity_server_integration.py` — 6 `server_integration` tests over real TCP, including the production WebSocket upgrade and the startup abort.
- `crates/bolt-core/src/middleware/rate_limit.rs` — 5 unit tests for bucket hashing: stability, separation, tag separation, long values, no concatenation collisions.
- `crates/bolt-core/tests/rate_limit_allocations.rs` — allocations per request.

Guard-ordering tests key on `api_key` while authenticating with JWT, so the rejected and the accepted caller share the no-identity bucket. Verified discriminating by injecting the defect and watching them go red.

`just test-py`: 2658 passed, 7 skipped. `cargo test --workspace`, `just lint`, bolt-mcp (177) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

Yes. The PR changes the HTTP, WebSocket, and test-client request paths.

The added work is required for identity-based rate limiting:

- Pre-authentication checks for IP and header keys.
- Authentication before user and API-key checks.
- Post-authentication identity resolution.
- Client-address fallback when no applicable identity exists.
- Separate limiter-key construction for identity buckets.

Identity-based routes perform two rate-limit phases. This adds branching and a second check, but the ordering is required for authentication guards and identity-aware buckets.

The limiter stores seeded 8-byte hashes instead of allocated key strings. This avoids per-request key allocations and removes the 256-byte key limit. Allocation tests verify the reduction.

IP- and header-based routes retain pre-authentication checks. They do not require identity resolution. The PR does not add unrelated work to requests that do not use rate limiting.

Overall, the hot-path impact is justified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->