### PR TITLE
fix(asgi): send http.disconnect to mounted apps and set TCP_NODELAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Performance
+
+- **`TCP_NODELAY` on every connection** - Bolt left Nagle's algorithm on. A response that Bolt writes in more than one segment waited for the delayed ACK of the client, about 40 ms per response. This hit every `StreamingResponse`, `EventSourceResponse`, and ASGI mount, `mount_django` included. On one keep-alive connection, an SSE route with three events went from 24 to 10,700 responses per second. A trivial ASGI mount went from 24 to 6,700. Single-write JSON responses did not change.
+
+### Fixed
+
+- **ASGI mount: a client that went away raised into the app** - Bolt had no client-disconnect signal for mounted apps. A mounted app that parked in `receive()` never got `http.disconnect`, and Actix kept its handler alive until the app wrote. After `BOLT_ASGI_MOUNT_TIMEOUT`, Bolt returned 504, cancelled the app, and dropped the response channel. On Django 4.2 to 6.0, `ASGIHandler.handle()` waits with `asyncio.wait()`, which does not cancel its child tasks. The orphaned `process_request` task finished the view, called `send()`, and got `RuntimeError: http.response.start sent more than once`. Django 6.1 uses a `TaskGroup` and was not affected. Bolt now does what hyper and uvicorn do. A read-side EOF while a handler runs is a disconnect (`h1_allow_half_closed(false)`). `receive()` then returns `http.disconnect`, before headers and mid-body. After Bolt closes a response, on disconnect, timeout, or app exit, `send()` is a no-op. A real second `http.response.start` still raises. (#313)
+
 ## [0.10.3]
 
 ### Added

--- a/crates/bolt-asgi/src/asgi_http.rs
+++ b/crates/bolt-asgi/src/asgi_http.rs
@@ -7,6 +7,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::{PyBytes, PyDict, PyList};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex, Notify};
@@ -27,6 +28,47 @@ struct AsgiSendState {
     body_tx: Mutex<Option<mpsc::Sender<Bytes>>>,
     /// Exception message from the ASGI coroutine, set by `AsgiDoneCallback`.
     exception_msg: Mutex<Option<String>>,
+    /// Set when the response is over for Bolt: the coroutine finished, the
+    /// header timeout fired, or the client went away. After this, `send` is a
+    /// no-op (a task that outlives the request must not raise) and `receive`
+    /// returns `http.disconnect`.
+    closed: AtomicBool,
+    /// Wakes a parked `receive()` when `closed` flips.
+    response_done: Notify,
+}
+
+impl AsgiSendState {
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.response_done.notify_waiters();
+    }
+}
+
+/// Dropped by Actix when the client goes away: before headers (the handler
+/// future is dropped) or mid-body (the body stream is dropped). Also dropped
+/// after a complete response, which is a no-op because `body_tx` is gone.
+struct ClientGoneGuard {
+    state: Arc<AsgiSendState>,
+    /// `false` when Bolt itself ends the response early (HEAD), so the drop
+    /// does not report a disconnect to an app that still has to send its body.
+    armed: bool,
+}
+
+impl Drop for ClientGoneGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let in_flight = self
+            .state
+            .body_tx
+            .lock()
+            .map(|guard| guard.is_some())
+            .unwrap_or(false);
+        if in_flight {
+            self.state.close();
+        }
+    }
 }
 
 const ASGI_MOUNT_BODY_CHANNEL_CAPACITY: usize = 32;
@@ -34,14 +76,14 @@ const ASGI_MOUNT_BODY_CHANNEL_CAPACITY: usize = 32;
 #[pyclass]
 struct AsgiReceive {
     body: Arc<AsyncMutex<Option<Vec<u8>>>>,
-    response_done: Arc<Notify>,
+    state: Arc<AsgiSendState>,
 }
 
 #[pymethods]
 impl AsgiReceive {
     fn __call__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let body = self.body.clone();
-        let response_done = self.response_done.clone();
+        let state = self.state.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let mut body_guard = body.lock().await;
@@ -56,7 +98,14 @@ impl AsgiReceive {
             }
             drop(body_guard);
 
-            response_done.notified().await;
+            // Register the waiter before reading the flag, so a `close()` that
+            // lands between the two cannot be missed.
+            let notified = state.response_done.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if !state.closed.load(Ordering::Acquire) {
+                notified.await;
+            }
             Python::attach(|py| {
                 let message = PyDict::new(py);
                 message.set_item("type", "http.disconnect")?;
@@ -82,6 +131,10 @@ impl AsgiSend {
             .get_item("type")?
             .ok_or_else(|| PyValueError::new_err("Missing ASGI message type"))?
             .extract()?;
+
+        if self.state.closed.load(Ordering::Acquire) {
+            return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(()) });
+        }
 
         match msg_type.as_str() {
             "http.response.start" => {
@@ -168,7 +221,6 @@ impl AsgiSend {
 #[pyclass]
 struct AsgiDoneCallback {
     state: Arc<AsgiSendState>,
-    response_done: Arc<Notify>,
 }
 
 #[pymethods]
@@ -207,7 +259,7 @@ impl AsgiDoneCallback {
             guard.take();
         }
 
-        self.response_done.notify_waiters();
+        self.state.close();
     }
 }
 
@@ -426,13 +478,18 @@ pub async fn handle_asgi_mount_request(
     // dispatching through spawn_blocking.
     let (body_tx, body_rx) = mpsc::channel::<Bytes>(ASGI_MOUNT_BODY_CHANNEL_CAPACITY);
     let (start_tx, start_rx) = oneshot::channel::<AsgiResponseStart>();
-    let response_done = Arc::new(Notify::new());
 
     let send_state = Arc::new(AsgiSendState {
         response_start_tx: Mutex::new(Some(start_tx)),
         body_tx: Mutex::new(Some(body_tx)),
         exception_msg: Mutex::new(None),
+        closed: AtomicBool::new(false),
+        response_done: Notify::new(),
     });
+    let mut client_gone = ClientGoneGuard {
+        state: send_state.clone(),
+        armed: true,
+    };
 
     let py_future: Py<PyAny> = match Python::attach(|py| -> PyResult<Py<PyAny>> {
         let scope = build_scope(py, &req, mount)?;
@@ -440,7 +497,7 @@ pub async fn handle_asgi_mount_request(
             py,
             AsgiReceive {
                 body: Arc::new(AsyncMutex::new(Some(request_body))),
-                response_done: response_done.clone(),
+                state: send_state.clone(),
             },
         )?;
         let send_obj = Py::new(
@@ -456,7 +513,6 @@ pub async fn handle_asgi_mount_request(
             py,
             AsgiDoneCallback {
                 state: send_state.clone(),
-                response_done: response_done.clone(),
             },
         )?;
         py_future
@@ -494,10 +550,10 @@ pub async fn handle_asgi_mount_request(
             }
         }
         _ = tokio::time::sleep(asgi_mount_timeout) => {
+            send_state.close();
             Python::attach(|py| {
                 let _ = py_future.call_method0(py, "cancel");
             });
-            response_done.notify_waiters();
             return HttpResponse::GatewayTimeout()
                 .content_type("text/plain; charset=utf-8")
                 .body(format!(
@@ -552,13 +608,17 @@ pub async fn handle_asgi_mount_request(
     }
 
     if req.method() == Method::HEAD {
+        // The body channel stays open; the app's body messages are dropped.
+        client_gone.armed = false;
         return builder.body(Vec::<u8>::new());
     }
 
-    let body_stream = stream::unfold(body_rx, |mut rx| async move {
+    // The guard rides along with the stream: Actix drops it when the client
+    // disconnects mid-body, which flips `closed` and wakes `receive()`.
+    let body_stream = stream::unfold((body_rx, client_gone), |(mut rx, guard)| async move {
         rx.recv()
             .await
-            .map(|chunk| (Ok::<Bytes, std::io::Error>(chunk), rx))
+            .map(|chunk| (Ok::<Bytes, std::io::Error>(chunk), (rx, guard)))
     });
     builder.streaming(body_stream)
 }

--- a/docs/src/topics/asgi-mounts.md
+++ b/docs/src/topics/asgi-mounts.md
@@ -119,6 +119,10 @@ That means Bolt-level middleware features (for example rate limits, Bolt auth gu
 - `BOLT_MAX_UPLOAD_SIZE` also applies to ASGI mount request bodies. Oversized bodies return `413 Payload Too Large`.
 - Request-body buffering for mounts currently has no dedicated read timeout before handoff to the mounted ASGI app. Enforce slow-client/read timeouts at your reverse proxy or ingress.
 
+## Client disconnects
+
+Bolt sends `http.disconnect` to `receive()` when the client goes away. This works before headers and mid-body. After that, `send()` is a no-op. The mounted app does not get an error for a client that is gone. A second `http.response.start` for a live client still raises. Django's `ASGIHandler` uses this signal to cancel the view.
+
 ## Testing
 
 `TestClient` and `AsyncTestClient` use the same mount conflict validation and mount dispatch behavior as production startup.

--- a/python/benchmark/BENCHMARK.md
+++ b/python/benchmark/BENCHMARK.md
@@ -1,267 +1,353 @@
 # Django-Bolt Benchmark
-Generated: Sun Aug 16 04:31:38 AM PKT 2026
+Generated: Sun Aug 30 11:18:42 AM PKT 2026
 Config: 8 processes × 1 workers | C=100 N=100000
 
 ## Root Endpoint Performance
-  Reqs/sec    305065.13   29913.58  336129.13
-  Latency      325.99us   323.72us     7.58ms
+  Reqs/sec    303178.31   16782.91  326182.62
+  Latency      326.65us   346.71us     8.12ms
   Latency Distribution
-     50%   230.00us
-     75%   332.00us
-     90%   542.00us
-     99%     2.29ms
+     50%   228.00us
+     75%   324.00us
+     90%   520.00us
+     99%     2.73ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
- 36499 / 100000 [==================================================================================>----------------------------------------------------------------------------------------------------------------------------------------------]  36.50% 182018/s
-  Reqs/sec    172734.27   14835.21  196457.53
-  Latency      576.26us   284.01us     6.12ms
+  Reqs/sec    174581.87   17795.59  196446.10
+  Latency      570.90us   317.11us     8.33ms
   Latency Distribution
-     50%   486.00us
-     75%   665.00us
-     90%     0.93ms
-     99%     2.49ms
+     50%   478.00us
+     75%   636.00us
+     90%     0.90ms
+     99%     2.52ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    174159.35   14123.84  198488.60
-  Latency      571.39us   324.29us     7.70ms
+  Reqs/sec    192499.81   16298.09  211304.98
+  Latency      516.38us   227.99us     6.71ms
   Latency Distribution
-     50%   496.00us
-     75%   666.00us
-     90%     0.93ms
-     99%     2.65ms
+     50%   464.00us
+     75%   612.00us
+     90%   808.00us
+     99%     1.79ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    253600.58   31778.72  355918.60
-  Latency      399.17us   261.07us     6.20ms
+  Reqs/sec    258076.14   26530.48  294140.09
+  Latency      382.00us   230.39us     5.40ms
   Latency Distribution
-     50%   318.00us
-     75%   432.00us
-     90%   658.00us
-     99%     1.95ms
+     50%   316.00us
+     75%   412.00us
+     90%   602.00us
+     99%     1.76ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    228166.19   32793.54  267521.82
-  Latency      435.58us   300.58us    11.13ms
+  Reqs/sec    259742.14   25013.08  287343.98
+  Latency      382.39us   270.00us     9.45ms
   Latency Distribution
-     50%   341.00us
-     75%   486.00us
-     90%   745.00us
-     99%     2.37ms
+     50%   308.00us
+     75%   424.00us
+     90%   602.00us
+     99%     1.96ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    252865.74   16164.36  274102.52
-  Latency      391.28us   195.34us     5.89ms
+  Reqs/sec    241332.31   20788.53  269652.34
+  Latency      410.32us   272.33us    11.40ms
   Latency Distribution
-     50%   329.00us
-     75%   437.00us
-     90%   638.00us
-     99%     1.56ms
+     50%   333.00us
+     75%   440.00us
+     90%   652.00us
+     99%     2.09ms
 ### HTML Response (/html)
-  Reqs/sec    291496.20   18752.92  314721.42
-  Latency      341.78us   271.64us     7.22ms
+  Reqs/sec    287718.80   17529.12  322213.39
+  Latency      344.29us   290.46us     7.01ms
   Latency Distribution
-     50%   266.00us
-     75%   375.00us
-     90%   552.00us
-     99%     1.97ms
+     50%   262.00us
+     75%   358.00us
+     90%   553.00us
+     99%     2.15ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     48365.74    4811.25   55075.00
-  Latency        2.07ms   516.92us    15.41ms
+  Reqs/sec     51649.64    5165.92   56708.20
+  Latency        1.93ms   533.39us    20.19ms
   Latency Distribution
-     50%     1.90ms
-     75%     2.47ms
-     90%     3.19ms
-     99%     4.80ms
+     50%     1.78ms
+     75%     2.30ms
+     90%     2.93ms
+     99%     4.31ms
 
 ## Native Static & Media File Serving
 ### Static 1KB CSS (GET /static/bench/asset_1k.css)
-  Reqs/sec    162100.42   13861.38  176561.96
-  Latency      613.87us   259.80us     9.77ms
+ 32903 / 100000 [==================================================================================>-----------------------------------------------------------------------------------------------------------------------------------------------------------------------]  32.90% 162295/s
+ 98498 / 100000 [======================================================================================================================================================================================================================================================>---]  98.50% 162816/s
+  Reqs/sec    162983.53    9681.66  176980.56
+  Latency      610.76us   274.35us    13.12ms
   Latency Distribution
-     50%   567.00us
-     75%   696.00us
-     90%   847.00us
-     99%     1.96ms
+     50%   589.00us
+     75%   683.00us
+     90%   833.00us
+     99%     1.88ms
 ### Static 1KB CSS (HEAD /static/bench/asset_1k.css)
-  Reqs/sec    169052.01    7207.12  182591.72
-  Latency      587.66us   184.45us     7.90ms
+  Reqs/sec    172203.57    9519.12  183491.53
+  Latency      578.32us   159.42us     6.63ms
   Latency Distribution
-     50%   549.00us
-     75%   643.00us
-     90%   757.00us
-     99%     1.59ms
+     50%   563.00us
+     75%   656.00us
+     90%   786.00us
+     99%     1.33ms
 ### Static 100KB JS (GET /static/bench/asset_100k.js)
- 17751 / 100000 [========================================>-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------]  17.75% 88450/s
-  Reqs/sec     88068.67    7908.65  100067.23
-  Latency        1.13ms     1.19ms    42.88ms
+  Reqs/sec     88460.17    8584.95   96269.75
+  Latency        1.13ms   485.26us    15.81ms
   Latency Distribution
-     50%     1.04ms
-     75%     1.29ms
-     90%     1.67ms
-     99%     3.44ms
+     50%     1.11ms
+     75%     1.31ms
+     90%     1.54ms
+     99%     2.80ms
 ### Static 404 miss (GET /static/bench/missing.css)
-  Reqs/sec    185854.03   14837.20  204664.70
-  Latency      535.61us   198.28us     6.08ms
+  Reqs/sec    187371.38    7993.75  198410.16
+  Latency      531.39us   186.82us     5.60ms
   Latency Distribution
-     50%   471.00us
-     75%   620.00us
-     90%   789.00us
-     99%     1.53ms
+     50%   495.00us
+     75%   614.00us
+     90%   801.00us
+     99%     1.50ms
 ### Media 1KB (GET /media/bench/upload_1k.bin)
-  Reqs/sec    159012.30    9068.00  172523.97
-  Latency      622.56us   166.74us     4.49ms
+  Reqs/sec    162110.86    6927.45  171729.62
+  Latency      614.29us   160.74us     5.57ms
   Latency Distribution
-     50%   562.00us
-     75%   745.00us
-     90%     0.93ms
-     99%     1.56ms
+     50%   563.00us
+     75%   711.00us
+     90%     0.88ms
+     99%     1.39ms
 ### Media 100KB (GET /media/bench/upload_100k.bin)
- 68903 / 100000 [===========================================================================================================================================================>----------------------------------------------------------------------]  68.90% 85797/s
-  Reqs/sec     87825.06    8400.51   99699.23
-  Latency        1.13ms     1.10ms    46.20ms
+  Reqs/sec     85699.71    5921.58   94205.03
+  Latency        1.16ms   339.02us    16.04ms
   Latency Distribution
-     50%     1.03ms
-     75%     1.34ms
+     50%     1.09ms
+     75%     1.35ms
      90%     1.76ms
-     99%     3.38ms
+     99%     3.02ms
 
 ## Authentication & Authorization Performance
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     39465.09    2591.55   41295.89
-  Latency        2.53ms   368.93us    12.52ms
+  Reqs/sec     40038.76    1472.81   42491.03
+  Latency        2.49ms   237.84us     9.14ms
   Latency Distribution
-     50%     2.48ms
-     75%     3.18ms
-     90%     3.47ms
-     99%     4.40ms
+     50%     2.44ms
+     75%     2.74ms
+     90%     3.60ms
+     99%     4.15ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec    151215.37    7275.07  165388.80
-  Latency      657.56us   212.68us     5.98ms
+  Reqs/sec    154967.36    8438.73  170828.00
+  Latency      639.01us   169.92us     6.60ms
   Latency Distribution
-     50%   645.00us
-     75%   802.00us
-     90%     0.97ms
-     99%     1.77ms
+     50%   607.00us
+     75%   757.00us
+     90%     0.92ms
+     99%     1.50ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    231157.67   41556.04  290363.40
-  Latency      429.04us   514.72us    12.45ms
+  Reqs/sec    265337.37   14851.48  287506.15
+  Latency      374.47us   325.10us     8.15ms
   Latency Distribution
-     50%   291.00us
-     75%   413.00us
-     90%   714.00us
-     99%     3.13ms
+     50%   287.00us
+     75%   386.00us
+     90%   565.00us
+     99%     2.58ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    234188.47   21590.78  269564.71
-  Latency      420.79us   327.01us     8.07ms
+  Reqs/sec    250639.38   16203.47  265017.79
+  Latency      395.24us   294.04us     7.17ms
   Latency Distribution
-     50%   325.00us
-     75%   444.00us
-     90%   675.00us
-     99%     2.63ms
+     50%   327.00us
+     75%   420.00us
+     90%   586.00us
+     99%     2.30ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     20722.28    1477.75   23829.00
-  Latency        4.82ms     2.33ms    94.61ms
+ 61900 / 100000 [=======================================================================================================================================================>--------------------------------------------------------------------------------------------]  61.90% 20597/s 00m01s
+  Reqs/sec     20693.12    1005.78   22003.15
+  Latency        4.83ms     1.47ms    57.06ms
   Latency Distribution
-     50%     4.71ms
-     75%     5.41ms
-     90%     6.11ms
-     99%     7.90ms
+     50%     4.75ms
+     75%     6.07ms
+     90%     7.28ms
+     99%     9.14ms
 ### Users Full10 (Sync) (/users/sync-full10)
- 43995 / 100000 [================================================================================================>--------------------------------------------------------------------------------------------------------------------------]  43.99% 15689/s 00m03s
-  Reqs/sec     15395.04    1195.93   19392.87
-  Latency        6.49ms     2.79ms    83.97ms
+ 28496 / 100000 [=====================================================================>------------------------------------------------------------------------------------------------------------------------------------------------------------------------------]  28.50% 15786/s 00m04s
+  Reqs/sec     15306.65    1246.87   19372.46
+  Latency        6.53ms     2.42ms    53.47ms
   Latency Distribution
-     50%     5.79ms
-     75%     7.90ms
-     90%    10.68ms
-     99%    16.71ms
+     50%     5.82ms
+     75%     7.88ms
+     90%    10.52ms
+     99%    17.00ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     26323.56    1393.94   28542.68
-  Latency        3.80ms     1.42ms    65.74ms
+ 91897 / 100000 [======================================================================================================================================================================================================================================>--------------------]  91.90% 25485/s
+  Reqs/sec     25512.99    1466.31   27178.33
+  Latency        3.92ms     0.95ms    32.86ms
   Latency Distribution
-     50%     3.73ms
-     75%     4.59ms
-     90%     5.32ms
-     99%     6.71ms
+     50%     3.81ms
+     75%     4.84ms
+     90%     5.81ms
+     99%     7.72ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    205941.21   18624.31  234423.29
-  Latency      479.39us   279.42us     8.02ms
+  Reqs/sec    169814.55   37236.21  235408.78
+  Latency      588.99us   437.09us     8.53ms
   Latency Distribution
-     50%   401.00us
-     75%   532.00us
-     90%   771.00us
-     99%     2.10ms
+     50%   416.00us
+     75%   628.00us
+     90%     1.05ms
+     99%     3.47ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    205027.85   16287.76  234909.79
-  Latency      485.09us   224.53us     5.95ms
+  Reqs/sec    206312.64   16599.29  232447.31
+  Latency      482.23us   216.41us     8.59ms
   Latency Distribution
-     50%   443.00us
-     75%   563.00us
-     90%   763.00us
-     99%     1.78ms
+     50%   418.00us
+     75%   569.00us
+     90%   775.00us
+     99%     1.77ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec    210782.88   21187.92  253089.53
-  Latency      469.37us   235.36us     9.02ms
+  Reqs/sec    222154.16   13955.81  246086.61
+  Latency      446.72us   190.56us    12.01ms
   Latency Distribution
-     50%   406.00us
-     75%   546.00us
-     90%   741.00us
-     99%     1.81ms
+     50%   383.00us
+     75%   544.00us
+     90%   706.00us
+     99%     1.33ms
 ### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec    192707.38   13367.51  212797.51
-  Latency      515.44us   257.32us     6.17ms
+  Reqs/sec    196236.76   20176.27  215260.93
+  Latency      501.95us   211.55us     6.50ms
   Latency Distribution
-     50%   446.00us
-     75%   574.00us
-     90%   811.00us
-     99%     1.92ms
+     50%   443.00us
+     75%   597.00us
+     90%   778.00us
+     99%     1.64ms
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    208627.54   26822.00  253753.92
-  Latency      475.89us   281.86us     7.97ms
+  Reqs/sec    236416.69   15639.92  258437.83
+  Latency      421.81us   263.12us     7.03ms
   Latency Distribution
-     50%   387.00us
-     75%   529.00us
-     90%   810.00us
-     99%     2.28ms
-### File Upload (POST /upload)
-  Reqs/sec    175890.87   15671.69  199768.20
-  Latency      565.42us   249.90us     6.38ms
-  Latency Distribution
-     50%   498.00us
-     75%   678.00us
-     90%     0.90ms
-     99%     2.07ms
-### Form Repeated Keys urlencoded (POST /form-list)
-  Reqs/sec    194831.64   19497.15  226346.99
-  Latency      511.34us   236.75us     7.02ms
-  Latency Distribution
-     50%   440.00us
-     75%   585.00us
-     90%   834.00us
-     99%     2.01ms
-### Form Repeated Keys multipart (POST /form-list)
-  Reqs/sec    150624.04   10189.56  167896.14
-  Latency      660.63us   204.21us     6.05ms
-  Latency Distribution
-     50%   602.00us
-     75%   782.00us
-     90%     1.03ms
+     50%   354.00us
+     75%   471.00us
+     90%   663.00us
      99%     1.83ms
+### File Upload (POST /upload)
+  Reqs/sec    186225.83   10614.02  204591.18
+  Latency      534.03us   205.83us     7.29ms
+  Latency Distribution
+     50%   476.00us
+     75%   604.00us
+     90%   823.00us
+     99%     1.66ms
+### Form Repeated Keys urlencoded (POST /form-list)
+  Reqs/sec    221656.62   19205.12  248451.57
+  Latency      449.21us   214.62us    12.25ms
+  Latency Distribution
+     50%   396.00us
+     75%   508.00us
+     90%   669.00us
+     99%     1.49ms
+### Form Repeated Keys multipart (POST /form-list)
+  Reqs/sec    162659.51    6283.07  169306.76
+  Latency      611.99us   134.61us     5.05ms
+  Latency Distribution
+     50%   578.00us
+     75%   750.00us
+     90%     0.90ms
+     99%     1.42ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
+  Reqs/sec      9027.32    1556.66   11591.14
+  Latency       10.98ms     8.75ms   192.97ms
+  Latency Distribution
+     50%     9.88ms
+     75%    11.06ms
+     90%    14.92ms
+     99%    20.96ms
+
+## Django Ninja-style Benchmarks
+### JSON Parse/Validate (POST /bench/parse)
+  Reqs/sec    255110.28   19290.87  282105.86
+  Latency      385.99us   287.75us     7.65ms
+  Latency Distribution
+     50%   307.00us
+     75%   420.00us
+     90%   595.00us
+     99%     2.23ms
+## Union Response Performance
+Polymorphic feed with tagged msgspec Struct union (PostActivity | CommentActivity | LikeActivity)
+
+### Feed of 100 mixed union items (/feed)
+  Reqs/sec     84212.84    8170.31   95447.50
+  Latency        1.18ms   274.21us     9.79ms
+  Latency Distribution
+     50%     1.06ms
+     75%     1.52ms
+     90%     1.86ms
+     99%     2.90ms
+
+## Latency Percentile Benchmarks
+Measures p50/p75/p90/p99 latency for type coercion overhead analysis
+
+### Baseline - No Parameters (/)
+  Reqs/sec    302845.00   27859.61  329866.80
+  Latency      322.09us   257.99us     8.09ms
+  Latency Distribution
+     50%   231.00us
+     75%   359.00us
+     90%   560.00us
+     99%     1.99ms
+
+### Path Parameter - int (/items/12345)
+  Reqs/sec    262794.30   22249.36  294314.36
+  Latency      377.96us   302.94us     9.19ms
+  Latency Distribution
+     50%   286.00us
+     75%   407.00us
+     90%   620.00us
+     99%     2.31ms
+
+### Path + Query Parameters (/items/12345?q=hello)
+  Reqs/sec    244161.24   44419.00  291117.99
+  Latency      408.38us   330.60us     9.43ms
+  Latency Distribution
+     50%   304.00us
+     75%   430.00us
+     90%   682.00us
+     99%     2.68ms
+
+### Header Parameter (/header)
+  Reqs/sec    251025.36   22598.82  288803.08
+  Latency      393.21us   277.91us    10.39ms
+  Latency Distribution
+     50%   314.00us
+     75%   438.00us
+     90%   618.00us
+     99%     2.16ms
+
+### Cookie Parameter (/cookie)
+  Reqs/sec    262952.95   19600.79  282687.84
+  Latency      377.43us   284.84us    10.02ms
+  Latency Distribution
+     50%   315.00us
+     75%   399.00us
+     90%   564.00us
+     99%     1.91ms
+
+### Auth Context - JWT validated, no DB (/auth/context)
+  Reqs/sec    153176.20   12120.46  161786.97
+  Latency      648.54us   194.24us     6.51ms
+  Latency Distribution
+     50%   623.00us
+     75%   799.00us
+     90%     0.99ms
+     99%     1.63ms

--- a/python/tests/integration/apps/asgi_disconnect.py
+++ b/python/tests/integration/apps/asgi_disconnect.py
@@ -1,0 +1,49 @@
+"""App under test for client disconnects against an ASGI mount.
+
+``/mounted/wait`` parks in ``receive()`` and records what it gets.
+``/mounted/stream`` sends headers, then streams until ``receive()`` returns.
+``/events`` reports what the mounted app observed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from django_bolt import BoltAPI
+
+api = BoltAPI()
+events: list[str] = []
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/events")
+async def get_events():
+    return {"events": events}
+
+
+async def mounted(scope, receive, send):
+    await receive()  # request body
+    if scope["path"] == "/wait":
+        try:
+            message = await asyncio.wait_for(receive(), timeout=3)
+            events.append(message["type"])
+        except TimeoutError:
+            events.append("timeout")
+        return
+
+    await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
+    disconnect = asyncio.ensure_future(receive())
+    while not disconnect.done():
+        await send({"type": "http.response.body", "body": b"tick\n", "more_body": True})
+        await asyncio.sleep(0.05)
+    events.append(disconnect.result()["type"])
+    # The client is gone. These sends must be silent no-ops.
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+    events.append("late-send-ok")
+
+
+api.mount_asgi("/mounted", mounted)

--- a/python/tests/integration/test_asgi_disconnect_server_integration.py
+++ b/python/tests/integration/test_asgi_disconnect_server_integration.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from .apps import app_module
+
+pytestmark = pytest.mark.server_integration
+
+
+def _abort_request(server, path: str, *, after_headers: bool) -> None:
+    sock = socket.create_connection((server.host, server.port), timeout=5)
+    sock.sendall(f"GET {path} HTTP/1.1\r\nHost: {server.host}\r\n\r\n".encode())
+    if after_headers:
+        head = b""
+        while b"\r\n\r\n" not in head:
+            chunk = sock.recv(4096)
+            assert chunk, "server closed before sending headers"
+            head += chunk
+        assert b"200 OK" in head
+    sock.close()
+
+
+def test_client_abort_before_headers_delivers_http_disconnect(make_server_project):
+    project = make_server_project(api_module=app_module("asgi_disconnect"))
+
+    with project.start() as server:
+        _abort_request(server, "/mounted/wait", after_headers=False)
+        events = server.wait_for_json("/events", lambda data: bool(data["events"]), timeout=2.5)
+
+    assert events["events"] == ["http.disconnect"]
+
+
+def test_client_abort_mid_body_delivers_http_disconnect_and_send_is_silent(make_server_project):
+    project = make_server_project(api_module=app_module("asgi_disconnect"))
+
+    with project.start() as server:
+        _abort_request(server, "/mounted/stream", after_headers=True)
+        events = server.wait_for_json("/events", lambda data: len(data["events"]) >= 2, timeout=2.5)
+
+    assert events["events"] == ["http.disconnect", "late-send-ok"]

--- a/python/tests/integration/test_tcp_nodelay_server_integration.py
+++ b/python/tests/integration/test_tcp_nodelay_server_integration.py
@@ -1,0 +1,26 @@
+"""Multi-write responses must not hit the Nagle + delayed-ACK stall (~40 ms per response)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from .apps import app_module
+
+pytestmark = pytest.mark.server_integration
+
+
+def test_streaming_responses_are_not_delayed_by_nagle(make_server_project):
+    project = make_server_project(api_module=app_module("compression_sse"))
+
+    with project.start() as server:
+        server.get("/sse")  # warm the keep-alive connection
+        started = time.perf_counter()
+        for _ in range(10):
+            response = server.get("/sse")
+            assert response.status_code == 200
+        elapsed = time.perf_counter() - started
+
+    # With Nagle on, each response pays ~41 ms (10 requests ≈ 410 ms).
+    assert elapsed < 0.2, f"10 SSE responses took {elapsed:.3f}s"

--- a/python/tests/test_asgi_mount.py
+++ b/python/tests/test_asgi_mount.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import threading
+import time
 
 import pytest
 from django.core.management.base import CommandError
@@ -455,3 +457,86 @@ def test_mount_asgi_exception_surfaces_in_response(exc_class, exc_msg, expected_
     assert response.status_code == 500
     for fragment in expected_fragments:
         assert fragment in response.text
+
+
+def test_mount_asgi_send_after_timeout_is_a_noop(settings):
+    """Regression for #313.
+
+    After Bolt times out and cancels the app, a task that outlives the
+    cancellation (Django <= 6.0 orphans ``process_request`` this way) must be
+    able to call ``send`` without ``http.response.start sent more than once``.
+    """
+    settings.BOLT_ASGI_MOUNT_TIMEOUT = 0.05
+    api = BoltAPI()
+    outcome: dict[str, object] = {}
+    done = threading.Event()
+
+    async def late_sender(send):
+        try:
+            await asyncio.sleep(0.2)
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"late", "more_body": False})
+            outcome["ok"] = True
+        except BaseException as exc:  # noqa: BLE001 - record what the orphan saw
+            outcome["error"] = repr(exc)
+        finally:
+            done.set()
+
+    async def orphaning_asgi(scope, receive, send):
+        await receive()
+        # shield() mimics asyncio.wait(): cancelling the outer task leaves the inner one running.
+        await asyncio.shield(late_sender(send))
+
+    api.mount_asgi("/slow", orphaning_asgi)
+
+    with TestClient(api) as client:
+        response = client.get("/slow")
+        assert response.status_code == 504
+        assert done.wait(timeout=2)
+
+    assert outcome == {"ok": True}
+
+
+def test_mount_asgi_duplicate_response_start_still_raises():
+    api = BoltAPI()
+    outcome: dict[str, object] = {}
+
+    async def double_start(scope, receive, send):
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        try:
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+        except RuntimeError as exc:
+            outcome["error"] = str(exc)
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    api.mount_asgi("/double", double_start)
+
+    with TestClient(api) as client:
+        assert client.get("/double").status_code == 200
+
+    assert outcome == {"error": "http.response.start sent more than once"}
+
+
+def test_mount_asgi_head_request_does_not_fake_a_disconnect():
+    api = BoltAPI()
+    seen: list[str] = []
+
+    async def app(scope, receive, send):
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        try:
+            message = await asyncio.wait_for(receive(), timeout=0.2)
+            seen.append(message["type"])
+        except TimeoutError:
+            seen.append("no-disconnect")
+        await send({"type": "http.response.body", "body": b"body", "more_body": False})
+
+    api.mount_asgi("/h", app)
+
+    with TestClient(api) as client:
+        response = client.head("/h")
+        assert response.status_code == 200
+        time.sleep(0.3)
+
+    assert seen == ["no-disconnect"]

--- a/python/tests/test_asgi_mount.py
+++ b/python/tests/test_asgi_mount.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import threading
-import time
 
 import pytest
 from django.core.management.base import CommandError
@@ -462,8 +461,8 @@ def test_mount_asgi_exception_surfaces_in_response(exc_class, exc_msg, expected_
 def test_mount_asgi_send_after_timeout_is_a_noop(settings):
     """Regression for #313.
 
-    After Bolt times out and cancels the app, a task that outlives the
-    cancellation (Django <= 6.0 orphans ``process_request`` this way) must be
+    Bolt times out and cancels the app. A task can outlive the cancellation
+    (Django <= 6.0 orphans ``process_request`` this way). That task must be
     able to call ``send`` without ``http.response.start sent more than once``.
     """
     settings.BOLT_ASGI_MOUNT_TIMEOUT = 0.05
@@ -521,6 +520,7 @@ def test_mount_asgi_duplicate_response_start_still_raises():
 def test_mount_asgi_head_request_does_not_fake_a_disconnect():
     api = BoltAPI()
     seen: list[str] = []
+    done = threading.Event()
 
     async def app(scope, receive, send):
         await receive()
@@ -530,6 +530,7 @@ def test_mount_asgi_head_request_does_not_fake_a_disconnect():
             seen.append(message["type"])
         except TimeoutError:
             seen.append("no-disconnect")
+        done.set()
         await send({"type": "http.response.body", "body": b"body", "more_body": False})
 
     api.mount_asgi("/h", app)
@@ -537,6 +538,6 @@ def test_mount_asgi_head_request_does_not_fake_a_disconnect():
     with TestClient(api) as client:
         response = client.head("/h")
         assert response.status_code == 200
-        time.sleep(0.3)
+        assert done.wait(timeout=2)
 
     assert seen == ["no-disconnect"]

--- a/src/server.rs
+++ b/src/server.rs
@@ -905,6 +905,17 @@ pub fn start_server(
                         }
                     })
                     .keep_alive(keep_alive)
+                    // Multi-write responses (streaming, SSE, ASGI mounts) hit
+                    // the Nagle + delayed-ACK 40 ms stall without TCP_NODELAY.
+                    .on_connect(|conn, _ext| {
+                        if let Some(stream) = conn.downcast_ref::<actix_web::rt::net::TcpStream>() {
+                            let _ = stream.set_nodelay(true);
+                        }
+                    })
+                    // A read-side EOF while a handler runs is a client that
+                    // went away. Drop the handler, so ASGI mounts get
+                    // `http.disconnect` (same as hyper/uvicorn).
+                    .h1_allow_half_closed(false)
                     .client_request_timeout(std::time::Duration::from_secs(0))
                     // Signals are handled by our own task below (WebSocket
                     // drain must run before the Actix graceful stop).

--- a/src/server.rs
+++ b/src/server.rs
@@ -910,7 +910,9 @@ pub fn start_server(
                     .on_connect(|conn, _ext| {
                         if let Some(stream) = conn.downcast_ref::<actix_web::rt::net::TcpStream>() {
                             if let Err(err) = stream.set_nodelay(true) {
-                                eprintln!("[django-bolt] Failed to set TCP_NODELAY on connection: {err}");
+                                eprintln!(
+                                    "[django-bolt] Failed to set TCP_NODELAY on connection: {err}"
+                                );
                             }
                         }
                     })

--- a/src/server.rs
+++ b/src/server.rs
@@ -909,7 +909,9 @@ pub fn start_server(
                     // the Nagle + delayed-ACK 40 ms stall without TCP_NODELAY.
                     .on_connect(|conn, _ext| {
                         if let Some(stream) = conn.downcast_ref::<actix_web::rt::net::TcpStream>() {
-                            let _ = stream.set_nodelay(true);
+                            if let Err(err) = stream.set_nodelay(true) {
+                                eprintln!("[django-bolt] Failed to set TCP_NODELAY on connection: {err}");
+                            }
                         }
                     })
                     // A read-side EOF while a handler runs is a client that


### PR DESCRIPTION
## Summary

- **ASGI mount disconnects (#313)**: Bolt had no client-disconnect signal for mounted apps. After `BOLT_ASGI_MOUNT_TIMEOUT`, Django 4.2–6.0's orphaned `process_request` task raised `RuntimeError: http.response.start sent more than once`. Bolt now treats a read-side EOF as a disconnect (`h1_allow_half_closed(false)`), `receive()` returns `http.disconnect` before headers and mid-body, and `send()` is a no-op after Bolt closes the response. A real second `http.response.start` still raises.
- **`TCP_NODELAY` on every connection**: Nagle + delayed ACK stalled every multi-write response by ~40 ms. On one keep-alive connection, an SSE route with three events went from 24 to 10,700 rps; a trivial ASGI mount from 24 to 6,700. Single-write JSON responses did not change.
- Docs, changelog, and refreshed benchmark numbers.

## Test plan

- [x] `python/tests/test_asgi_mount.py` — in-process disconnect / no-op `send()` cases
- [x] `python/tests/integration/test_asgi_disconnect_server_integration.py` — real TCP client that drops mid-request
- [x] `python/tests/integration/test_tcp_nodelay_server_integration.py` — multi-write response latency on real TCP

https://claude.ai/code/session_01CgeR5ir93Kw7A5SFDnd6TG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

Yes. The PR touches the hot request path.

- `TCP_NODELAY` is configured once per accepted connection, not once per request.
- ASGI response handling performs an atomic `closed` check before `send()`.
- ASGI receive handling checks the same atomic state before waiting.
- `ClientGoneGuard` is attached to the request body stream.

These operations are required for disconnect detection and safe post-disconnect behavior. The checks are small atomic operations. The receive path avoids unnecessary waits by checking the closed state before awaiting. No clearly avoidable expensive work appears in the request path.

The main performance change is intentional. `TCP_NODELAY` prevents delays for multi-write responses, including streaming responses and SSE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->