### PR TITLE
Add Django system checks and migration warnings to runbolt startup

### DIFF
--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -358,6 +358,9 @@ The `runbolt` management command accepts these options:
 | `--no-admin` | off | Disable admin integration |
 | `--backlog` | `1024` | Socket listen backlog |
 | `--keep-alive` | OS default | HTTP keep-alive timeout |
+| `--skip-checks` | off | Skip the Django system checks at startup |
+
+At startup, `runbolt` runs the Django system checks and the migration check, like `runserver`. A check error stops startup. The unapplied-migration warning prints before the banner. In `--dev` mode, each reload runs the checks again. Multi-process mode runs them once, in the parent process. `--skip-checks` skips the system checks; the migration check still runs.
 
 ### Examples
 

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.db import connections
 from django.template.autoreload import get_template_directories
 from django.utils.autoreload import iter_all_python_module_files
 
@@ -530,7 +531,12 @@ def _project_api_module_names(root_urlconf: str) -> list[str]:
 class Command(BaseCommand):
     help = "Run Django-Bolt server with autodiscovered APIs"
 
+    # Like runserver: handle() runs the checks itself, at the right point.
+    # The dev supervisor skips them; each spawned dev worker runs them.
+    requires_system_checks = []
+
     def add_arguments(self, parser):
+        parser.add_argument("--skip-checks", action="store_true", help="Skip system checks.")
         parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
         parser.add_argument("--port", type=int, default=8000, help="Port to bind to (default: 8000)")
         parser.add_argument("--processes", type=int, default=1, help="Number of processes (default: 1)")
@@ -614,12 +620,32 @@ class Command(BaseCommand):
 
             self.run_with_autoreload(options)
         else:
+            # Mirror runserver: run the checks before the port is bound.
+            # Multi-process mode runs them once here, before workers fork.
+            # In dev mode each spawned worker gets here, so a reload runs
+            # the checks again, like runserver's autoreload.
+            self.run_startup_checks(options)
+
             # Production mode. Worker recycling needs the supervising parent
             # even for a single worker, so route through start_multiprocess.
             if processes > 1 or (self._supervision_requested(options) and not dev_worker_mode):
                 self.start_multiprocess(options)
             else:
                 self.start_single_process(options, dev_mode=effective_dev_mode)
+
+    def run_startup_checks(self, options) -> None:
+        """Run Django's system checks and the unapplied-migration check.
+
+        A check error raises SystemCheckError, which stops startup with a
+        non-zero exit code, like runserver.
+        """
+        if not options.get("skip_checks"):
+            self.check(display_num_errors=True)
+        self.check_migrations()
+        # Close the connections that the migration check opened. Handlers
+        # and forked workers must open their own.
+        for connection in connections.all(initialized_only=True):
+            connection.close()
 
     def run_with_autoreload(self, options):
         """Run the server behind the native dev supervisor."""

--- a/python/tests/integration/test_runbolt_server_integration.py
+++ b/python/tests/integration/test_runbolt_server_integration.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 
 import pytest
 
 from .apps import app_bytes, app_module, app_source
+from .helpers import _terminate_process
 
 pytestmark = pytest.mark.server_integration
 
@@ -52,6 +54,70 @@ def test_runbolt_applies_global_cors_settings_at_startup(make_server_project):
 
     assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == "https://example.com"
+
+
+def test_runbolt_prints_system_checks_and_migration_warning(make_server_project):
+    """runbolt prints runserver-style startup diagnostics before the banner.
+
+    The default test project installs contenttypes and auth on a fresh
+    SQLite database, so unapplied migrations always exist.
+    """
+    project = make_server_project()
+
+    server = project.start()
+    stdout, _stderr = server.stop()
+
+    assert "System check identified no issues" in stdout, stdout
+    assert "unapplied migration" in stdout, stdout
+    assert "Run 'python manage.py migrate' to apply them." in stdout, stdout
+    # The checks run once, before the Bolt banner.
+    assert stdout.count("unapplied migration") == 1, stdout
+    assert stdout.index("unapplied migration") < stdout.index("Django Bolt"), stdout
+
+
+def test_runbolt_skip_checks_suppresses_system_checks(make_server_project):
+    project = make_server_project()
+
+    server = project.start(extra_args=["--skip-checks"])
+    stdout, _stderr = server.stop()
+
+    assert "System check identified" not in stdout, stdout
+    # The migration warning still prints, like runserver.
+    assert "unapplied migration" in stdout, stdout
+
+
+def test_runbolt_failing_system_check_stops_startup(make_server_project):
+    project = make_server_project(
+        installed_apps=["badapp.apps.BadAppConfig"],
+        extra_files={
+            "badapp/__init__.py": "",
+            "badapp/apps.py": """
+            from django.apps import AppConfig
+            from django.core import checks
+
+
+            class BadAppConfig(AppConfig):
+                name = "badapp"
+
+                def ready(self):
+                    checks.register(self._fail)
+
+                @staticmethod
+                def _fail(app_configs, **kwargs):
+                    return [checks.Error("intentional failing check", id="badapp.E001")]
+            """,
+        },
+    )
+
+    process, _port = project.spawn()
+    try:
+        stdout, stderr = process.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        _terminate_process(process)
+        pytest.fail("runbolt kept running despite a failing system check")
+
+    assert process.returncode != 0, f"stdout:\n{stdout}\nstderr:\n{stderr}"
+    assert "badapp.E001" in stderr, f"stdout:\n{stdout}\nstderr:\n{stderr}"
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Multiprocess smoke only runs on Linux.")


### PR DESCRIPTION
Mirror `runserver` behavior by running Django's system checks and migration check at startup. A check error stops startup with a non-zero exit code. The unapplied-migration warning prints before the banner.

In `--dev` mode, each reload runs the checks again. Multi-process mode runs them once in the parent process before workers fork. Add `--skip-checks` to skip system checks; the migration check still runs.

## How was this tested?

- Added three new integration tests:
  - `test_runbolt_prints_system_checks_and_migration_warning` — verifies checks run and migration warning appears before the banner
  - `test_runbolt_skip_checks_suppresses_system_checks` — confirms `--skip-checks` suppresses system checks but not migration warnings
  - `test_runbolt_failing_system_check_stops_startup` — ensures a failing check stops startup with non-zero exit code
- Existing tests pass

## Performance consideration

Checks run once at startup (or once per reload in dev mode), not on the hot path. Connection cleanup after the migration check ensures handlers and forked workers open their own connections.

https://claude.ai/code/session_016V5gEFPMbjC65RbYEYNS4J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

The PR does not touch the hot request path.

The changes run during `runbolt` startup, before the server binds its port or workers start. In development mode, checks run during reload startup. In multi-process mode, checks run in the parent process before workers fork.

The PR adds no per-request checks, migration queries, or connection cleanup. It does not add request-time overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->