### PR TITLE
Bump PyO3 from 0.29.0 to 0.29.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "chrono",
  "libc",
@@ -1980,18 +1980,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2011,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/dj-bolt/django-bolt"
 # NOTE: "extension-module" is NOT hardcoded here — maturin enables it via
 # pyproject.toml's [tool.maturin] features. This lets `cargo test`
 # link libpython normally for native tests.
-pyo3 = { version = "0.29", features = ["abi3-py312", "chrono"] }
+pyo3 = { version = "0.29.2", features = ["abi3-py312", "chrono"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 actix-web = { version = "4", features = ["compress-gzip", "compress-brotli", "compress-zstd", "cookies"] }
 actix-http = "3"


### PR DESCRIPTION
Update the workspace pin so the lockfile picks up the 0.29.2 patch release fixes.

Fixes #306


<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes #


## How was this tested?

- [ ] `just lint-lib` and `just test-py` pass
- [ ] If Rust was changed: `just rebuild` succeeds
- [ ] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

<!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- The PR does not touch the hot request path.
- It changes only the workspace `pyo3` dependency from `0.29` to `0.29.2`.
- It retains the `abi3-py312` and `chrono` features.
- No request-path logic or runtime work changes.
- The dependency update is required to obtain the PyO3 patch fixes and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->