### PR TITLE
fix(json): encode str subclasses such as Django SafeString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **JSON encoding of `str` subclasses** - msgspec sends a `str` subclass, for example Django's `SafeString` from `mark_safe()`, to the encoder hook. The hook had no entry for `str` and raised `TypeError`. Such values now encode as a plain string.
 - **`django_middleware=[...]` loads the list you pass** - The list form was a filter over `settings.MIDDLEWARE`. A path not in `settings.MIDDLEWARE`, a class object, or a typo was dropped with no error, and the route ran with no Django middleware. The list is now loaded as given, in order. A non-string entry raises `ImproperlyConfigured`. A path that does not import raises `ImportError` at startup, as in Django. The `include`/`exclude` dict form still filters `settings.MIDDLEWARE`.
 - **`django_middleware`: `request.META` is the Rust-built dict** - The adapter built a second `META` in Python with no `REMOTE_ADDR` and a fixed `SERVER_NAME`. Middleware that reads the client address (django-debug-toolbar, django-axes, django-ratelimit) got `KeyError` or never matched. Django middleware and the handler now share the one `META` that Rust builds and caches, with `REMOTE_ADDR` from the client-ip resolver and `SERVER_NAME` from `Host`. The `request.state["META"]` round trip is gone.
 

--- a/python/django_bolt/_json.py
+++ b/python/django_bolt/_json.py
@@ -35,6 +35,11 @@ T = TypeVar("T")
 # Default type encoders for non-JSON-native types
 # Maps type -> encoder function
 DEFAULT_TYPE_ENCODERS: dict[type, Callable[[Any], Any]] = {
+    # msgspec delegates str subclasses (for example Django's SafeString) to
+    # enc_hook. Call the base descriptor to guarantee an exact str --
+    # SafeString.__str__ returns itself. Ordinary strings stay on msgspec's
+    # native fast path and never reach this mapping.
+    str: str.__str__,
     # Enum members -> primitive value
     Enum: lambda v: v.value,
     # Paths

--- a/python/tests/test_json_encoding.py
+++ b/python/tests/test_json_encoding.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import msgspec
+from django.utils.safestring import mark_safe
+
+from django_bolt import _json
+
+
+def test_encode_django_safe_string() -> None:
+    value = mark_safe("<strong>Hello</strong>")
+
+    encoded = _json.encode({"html": value})
+
+    assert msgspec.json.decode(encoded) == {"html": "<strong>Hello</strong>"}
+    assert type(msgspec.json.decode(encoded)["html"]) is str


### PR DESCRIPTION
## Problem

msgspec hands any `str` subclass to `enc_hook`. `DEFAULT_TYPE_ENCODERS` had no entry for `str`, so a value from `mark_safe()` (Django `SafeString`) in a response raised `TypeError`.

## Fix

Map `str` to `str.__str__` in `DEFAULT_TYPE_ENCODERS`. The base descriptor returns an exact `str` (`SafeString.__str__` returns itself). Ordinary strings stay on msgspec's native path and never reach the hook, so there is no per-value cost for the common case.

## Tests

`python/tests/test_json_encoding.py`: encoding `{"html": mark_safe(...)}` fails with `TypeError` before the fix and yields a plain `str` after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The PR touches the JSON encoding path used for responses.

The change is efficient. It adds `str` to `DEFAULT_TYPE_ENCODERS` and maps it to `str.__str__`. Ordinary `str` values continue through msgspec’s native fast path. Only `str` subclasses, such as Django’s `SafeString`, use the encoder hook and require conversion.

The added work is required to encode `str` subclasses correctly. The PR does not add unnecessary work for ordinary strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->