### PR TITLE
feat: HTTPException.body for typed error responses; status-based access-log levels

### DIFF
--- a/docs/src/topics/logging.md
+++ b/docs/src/topics/logging.md
@@ -308,9 +308,9 @@ If no `LOGGING` is configured, Django-Bolt sets up sensible defaults with queue-
 
 ### Access log
 
-The Rust server writes one line per response to the `django.server` logger:
+The Rust server writes one line for each response from a matched route to the `django.server` logger:
 
-```
+```text
 GET /items/7 200 0.4ms
 ```
 

--- a/docs/src/topics/logging.md
+++ b/docs/src/topics/logging.md
@@ -306,6 +306,24 @@ LOGGING = {
 
 If no `LOGGING` is configured, Django-Bolt sets up sensible defaults with queue-based handlers.
 
+### Access log
+
+The Rust server writes one line per response to the `django.server` logger:
+
+```
+GET /items/7 200 0.4ms
+```
+
+The log level follows the status code, the same as Django's `runserver`:
+
+| Status | Level |
+|---|---|
+| 1xx–3xx | `INFO` |
+| 4xx | `WARNING` |
+| 5xx | `ERROR` |
+
+Set `django.server` to `WARNING` to keep only the 4xx and 5xx lines. Set it above `WARNING` to turn the access log off. The check runs once at startup. When the log is off, the request path has no logging code.
+
 ## Example: Complete production setup
 
 ```python

--- a/docs/src/topics/responses.md
+++ b/docs/src/topics/responses.md
@@ -442,7 +442,7 @@ async def get_user(user_id: int) -> User:
 
 ### Per-status-code response schemas
 
-`response_model` also accepts a dict mapping status codes to types. This enables per-status-code validation and generates separate OpenAPI response entries for each code.
+`response_model` also accepts a dict mapping status codes to types. Each code gets its own OpenAPI response entry. Bolt encodes the body as-is and does not validate it.
 
 ```python
 import msgspec
@@ -465,8 +465,8 @@ async def get_item(item_id: int):
 **Tuple return** — Return `(status_code, data)` to select the schema by code:
 
 ```python
-return 200, {"id": 1, "name": "Alice"}   # validates against Item
-return 404, {"detail": "Not found"}       # validates against Error
+return 200, {"id": 1, "name": "Alice"}   # documented as Item
+return 404, {"detail": "Not found"}       # documented as Error
 ```
 
 **JSON() return** — `JSON(data, status_code=...)` also selects the schema:
@@ -480,7 +480,7 @@ return JSON({"detail": "Not found"}, status_code=404)
 ```python
 @api.get("/items", response_model={200: list[Item], 400: Error})
 async def list_items():
-    return [{"id": 1, "name": "Alice"}]  # validates against list[Item] at 200
+    return [{"id": 1, "name": "Alice"}]  # documented as list[Item] at 200
 ```
 
 **204 No Content** — Use `{204: None}` with `return (204, None)` for empty body responses:
@@ -494,12 +494,12 @@ async def delete_item(item_id: int):
     return 204, None
 ```
 
-**Ellipsis catch-all** — Use `...` as a key to match any unmapped status code:
+**Ellipsis catch-all** — Use `...` as a key to document any unmapped status code:
 
 ```python
 @api.get("/items/{item_id}", response_model={200: Item, ...: Error})
 async def get_item(item_id: int):
-    ...  # any non-200 status code validates against Error
+    ...  # any non-200 status code is documented as Error
 ```
 
 **Explicit status_code** — Override the auto-detected default status code:
@@ -510,7 +510,17 @@ async def create_item():
     return {"id": 1, "name": "New"}  # bare return uses 201 instead of auto-detected
 ```
 
-**Validation** — If the returned data doesn't match the schema for the status code, a 500 error is returned.
+**Typed error bodies** — Raise `HTTPException` with `body=` to send a typed body from anywhere. The handler return annotation stays the success type, so type checkers can check it:
+
+```python
+@api.post("/plans/{pk}/start", response_model={200: Plan, 400: Error})
+async def start_plan(request, pk: int) -> Plan:
+    if not healthy:
+        raise HTTPException(400, body=Error(detail="not healthy"))
+    return Plan(id=pk)
+```
+
+`body` replaces the default `{"detail": ...}` envelope. Bolt encodes it as-is and does not validate it. An unmapped status code is sent as-is too.
 
 ## Setting default status codes
 

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -40,7 +40,7 @@ from .auth import get_default_authentication_classes, register_auth_backend
 from .auth.user_loader import default_django_user_loader, resolve_user_loader
 from .concurrency import run_in_orm_executor, sync_to_thread
 from .decorators import _RESPONSE_MODEL_UNSET, ActionHandler
-from .error_handlers import handle_exception
+from .error_handlers import handle_exception, http_exception_handler
 from .exceptions import HTTPException
 from .logging.middleware import LoggingMiddleware, create_logging_middleware
 from .middleware import CompressionConfig
@@ -1581,11 +1581,16 @@ class BoltAPI:
                 resolved_metas: dict[int | type(...), dict] = {}
                 field_names_map = meta.get("response_field_names_map", {})
                 handler_default_status = meta["default_status_code"]
-                for code, resp_type in meta["response_map"].items():
+                # Per-status bodies are encoded as-is, never validated.
+                # The dict documents the schema only.
+                response_map = meta["response_map"]
+                if ... not in response_map:
+                    response_map = {**response_map, ...: Any}
+                for code, resp_type in response_map.items():
                     entry: dict = {
                         "response_type": resp_type,
                         "default_status_code": code if isinstance(code, int) else handler_default_status,
-                        "validate_response": route_validate_response,
+                        "validate_response": False,
                         "_stream_info": _extract_stream_item_type(resp_type),
                     }
                     if code in field_names_map:
@@ -1771,14 +1776,10 @@ class BoltAPI:
             default_status = meta["default_status_code"]
             default_entry = resolved_metas.get(default_status) or next(iter(resolved_metas.values()))
 
+            catch_all_entry = resolved_metas[...]
+
             def _lookup(code: int) -> dict:
-                entry = resolved_metas.get(code)
-                if entry is None:
-                    entry = resolved_metas.get(...)  # ellipsis catch-all
-                if entry is None:
-                    defined = sorted(c for c in resolved_metas if c is not ...)
-                    raise TypeError(f"Status {code} has no response schema. Defined: {defined}")
-                return entry
+                return resolved_metas.get(code, catch_all_entry)
 
             async def _dispatch_multi_async(result: Any) -> ResponseWireV1:
                 # Tuple (status, data): the primary multi-response return pattern.
@@ -1797,9 +1798,8 @@ class BoltAPI:
 
                 # JSON() with explicit status: pick schema by its status_code.
                 if isinstance(result, _JSONResponse):
-                    entry = resolved_metas.get(result.status_code) or resolved_metas.get(...)
-                    if entry is not None:
-                        return await entry["_response_type_handler"](result)
+                    entry = _lookup(result.status_code)
+                    return await entry["_response_type_handler"](result)
 
                 # Bare dict/list or any other type: use the default status schema.
                 return await serialize_response(result, default_entry)
@@ -1820,9 +1820,8 @@ class BoltAPI:
 
                 # JSON() with explicit status: pick schema by its status_code.
                 if isinstance(result, _JSONResponse):
-                    entry = resolved_metas.get(result.status_code) or resolved_metas.get(...)
-                    if entry is not None:
-                        return entry["_response_type_handler_sync"](result)
+                    entry = _lookup(result.status_code)
+                    return entry["_response_type_handler_sync"](result)
 
                 return serialize_response_sync(result, default_entry)
 
@@ -2480,17 +2479,7 @@ class BoltAPI:
 
     def _handle_http_exception(self, he: HTTPException) -> Response:
         """Handle HTTPException and return response."""
-        try:
-            body = _json.encode({"detail": he.detail})
-            headers = [("content-type", "application/json")]
-        except Exception:
-            body = str(he.detail).encode()
-            headers = [("content-type", "text/plain; charset=utf-8")]
-
-        if he.headers:
-            headers.extend([(k.lower(), v) for k, v in he.headers.items()])
-
-        return _wire_from_error_parts(int(he.status_code), headers, body)
+        return _wire_from_error_parts(*http_exception_handler(he))
 
     def _handle_generic_exception(self, e: Exception, request: dict[str, Any] = None) -> Response:
         """Handle generic exception using error_handlers module."""

--- a/python/django_bolt/error_handlers.py
+++ b/python/django_bolt/error_handlers.py
@@ -37,6 +37,18 @@ except ImportError:
     ExceptionReporter = None
 
 
+def _json_response(
+    status_code: int, headers: dict[str, str] | None, payload: Any
+) -> tuple[int, list[tuple[str, str]], bytes]:
+    """Encode ``payload`` as a JSON response tuple with optional extra headers."""
+    if headers:
+        response_headers = list(_DEFAULT_JSON_HEADERS)
+        response_headers.extend(headers.items())
+    else:
+        response_headers = _DEFAULT_JSON_HEADERS
+    return status_code, response_headers, _json.encode(payload)
+
+
 def format_error_response(
     status_code: int,
     detail: Any,
@@ -55,19 +67,9 @@ def format_error_response(
         Tuple of (status_code, headers, body)
     """
     error_body: dict[str, Any] = {"detail": detail}
-
     if extra is not None:
         error_body["extra"] = extra
-
-    body_bytes = _json.encode(error_body)
-
-    if headers:
-        response_headers = list(_DEFAULT_JSON_HEADERS)
-        response_headers.extend(headers.items())
-    else:
-        response_headers = _DEFAULT_JSON_HEADERS
-
-    return status_code, response_headers, body_bytes
+    return _json_response(status_code, headers, error_body)
 
 
 def serialize_django_response(response: Any) -> tuple[int, list[tuple[str, str]], bytes]:
@@ -118,14 +120,12 @@ def is_django_response(obj: Any) -> bool:
 
 
 def http_exception_handler(exc: HTTPException) -> tuple[int, list[tuple[str, str]], bytes]:
-    """Handle HTTPException and convert to error response.
+    """Convert an HTTPException to a response tuple.
 
-    Args:
-        exc: HTTPException instance
-
-    Returns:
-        Tuple of (status_code, headers, body)
+    A typed ``body`` is encoded as-is. Otherwise the ``detail`` envelope is used.
     """
+    if exc.body is not None:
+        return _json_response(exc.status_code, exc.headers, exc.body)
     return format_error_response(
         status_code=exc.status_code,
         detail=exc.detail,

--- a/python/django_bolt/exceptions.py
+++ b/python/django_bolt/exceptions.py
@@ -48,6 +48,8 @@ class HTTPException(BoltException):
     """Headers to attach to the response."""
     extra: dict[str, Any] | list[Any] | None = None
     """Additional data to include in the response."""
+    body: Any = None
+    """Typed response body. When set, it replaces the ``detail`` envelope."""
 
     def __init__(
         self,
@@ -55,6 +57,8 @@ class HTTPException(BoltException):
         detail: Any | None = None,
         headers: dict[str, str] | None = None,
         extra: dict[str, Any] | list[Any] | None = None,
+        *,
+        body: Any = None,
     ):
         """Initialize HTTPException.
 
@@ -63,6 +67,8 @@ class HTTPException(BoltException):
             detail: Exception details or message
             headers: HTTP headers to include in response
             extra: Additional data to include in response
+            body: Typed body (for example a msgspec Struct). Encoded as-is,
+                not validated. Declare its schema with ``response_model={code: Type}``.
         """
         # Handle detail
         if detail is None:
@@ -75,6 +81,7 @@ class HTTPException(BoltException):
         self.detail = detail_str if detail_str else HTTPStatus(self.status_code).phrase
         self.headers = headers or {}
         self.extra = extra
+        self.body = body
 
         # Update args for better error messages
         self.args = (f"{self.status_code}: {self.detail}",)

--- a/python/tests/integration/apps/access_log_levels.py
+++ b/python/tests/integration/apps/access_log_levels.py
@@ -1,0 +1,28 @@
+"""Access-log level app: one route per status class."""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI
+from django_bolt.exceptions import HTTPException
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/gone")
+async def gone():
+    raise HTTPException(404, detail="gone")
+
+
+@api.get("/down")
+async def down():
+    raise HTTPException(503, detail="down")
+
+
+@api.get("/teapot", response_model={200: dict, 418: dict})
+async def teapot():
+    return 418, {"detail": "teapot"}

--- a/python/tests/integration/apps/http_exception_body.py
+++ b/python/tests/integration/apps/http_exception_body.py
@@ -1,0 +1,43 @@
+"""HTTPException.body app: typed error bodies through the real error wire."""
+
+from __future__ import annotations
+
+import msgspec
+
+from django_bolt import BoltAPI
+from django_bolt.exceptions import HTTPException, NotFound
+
+
+class PlanRead(msgspec.Struct):
+    id: int
+
+
+class PlanError(msgspec.Struct):
+    error: str
+    code: int = 1
+
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.post("/plans/{pk}/start", response_model={200: PlanRead, 400: PlanError, 404: PlanError})
+async def start_plan(request, pk: int) -> PlanRead:
+    if pk == 0:
+        raise HTTPException(400, body=PlanError(error="not healthy"), headers={"X-Reason": "health"})
+    if pk == 1:
+        raise NotFound(body=PlanError(error="missing", code=7))
+    if pk == 2:
+        raise HTTPException(400, detail="plain")
+    return PlanRead(id=pk)
+
+
+@api.post("/plans-sync/{pk}/start", response_model={200: PlanRead, 400: PlanError})
+def start_plan_sync(request, pk: int) -> PlanRead:
+    if pk == 0:
+        raise HTTPException(400, body=PlanError(error="not healthy"))
+    return PlanRead(id=pk)

--- a/python/tests/integration/test_access_log_levels_server_integration.py
+++ b/python/tests/integration/test_access_log_levels_server_integration.py
@@ -1,0 +1,53 @@
+"""The Rust access log picks the level from the response status, like Django."""
+
+from __future__ import annotations
+
+import pytest
+
+from .apps import app_module
+
+_LOGGING = """
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"plain": {"format": "%(levelname)s %(message)s"}},
+    "handlers": {
+        "file": {
+            "class": "logging.FileHandler",
+            "filename": str(BASE_DIR / "access.log"),
+            "formatter": "plain",
+        }
+    },
+    "loggers": {
+        "django.server": {"handlers": ["file"], "level": "{level}", "propagate": False}
+    },
+}
+"""
+
+
+def _run(make_server_project, level: str) -> list[str]:
+    project = make_server_project(
+        api_module=app_module("access_log_levels"),
+        settings_extra=_LOGGING.replace("{level}", level),
+    )
+    with project.start(startup_path="/health") as server:
+        for path in ("/health", "/gone", "/down", "/teapot"):
+            server.request("GET", path)
+    return project.path("access.log").read_text().splitlines()
+
+
+@pytest.mark.server_integration
+def test_access_log_levels_follow_status(make_server_project):
+    lines = _run(make_server_project, "INFO")
+    assert any(line.startswith("INFO GET /health 200") for line in lines)
+    assert any(line.startswith("WARNING GET /gone 404") for line in lines)
+    assert any(line.startswith("WARNING GET /teapot 418") for line in lines)
+    assert any(line.startswith("ERROR GET /down 503") for line in lines)
+
+
+@pytest.mark.server_integration
+def test_access_log_at_warning_keeps_only_errors(make_server_project):
+    lines = _run(make_server_project, "WARNING")
+    assert not any("/health" in line for line in lines)
+    assert any(line.startswith("WARNING GET /gone 404") for line in lines)
+    assert any(line.startswith("ERROR GET /down 503") for line in lines)

--- a/python/tests/integration/test_http_exception_body_server_integration.py
+++ b/python/tests/integration/test_http_exception_body_server_integration.py
@@ -1,0 +1,35 @@
+"""HTTPException.body over a real ``runbolt`` server (async and sync dispatch)."""
+
+from __future__ import annotations
+
+import pytest
+
+from .apps import app_module
+
+
+@pytest.mark.server_integration
+def test_http_exception_body_end_to_end(make_server_project):
+    project = make_server_project(api_module=app_module("http_exception_body"))
+    with project.start(startup_path="/health") as server:
+        typed = server.request("POST", "/plans/0/start")
+        subclass = server.request("POST", "/plans/1/start")
+        plain = server.request("POST", "/plans/2/start")
+        ok = server.request("POST", "/plans/3/start")
+        sync_typed = server.request("POST", "/plans-sync/0/start")
+
+    assert typed.status_code == 400
+    assert typed.json() == {"error": "not healthy", "code": 1}
+    assert typed.headers["x-reason"] == "health"
+    assert typed.headers["content-type"].startswith("application/json")
+
+    assert subclass.status_code == 404
+    assert subclass.json() == {"error": "missing", "code": 7}
+
+    assert plain.status_code == 400
+    assert plain.json() == {"detail": "plain"}
+
+    assert ok.status_code == 200
+    assert ok.json() == {"id": 3}
+
+    assert sync_typed.status_code == 400
+    assert sync_typed.json() == {"error": "not healthy", "code": 1}

--- a/python/tests/test_http_exception_body.py
+++ b/python/tests/test_http_exception_body.py
@@ -1,0 +1,59 @@
+"""HTTPException.body: a typed error body, encoded as-is."""
+
+from __future__ import annotations
+
+import msgspec
+
+from django_bolt import BoltAPI
+from django_bolt.exceptions import HTTPException, NotFound
+from django_bolt.testing import TestClient
+
+
+class PlanRead(msgspec.Struct):
+    id: int
+
+
+class PlanError(msgspec.Struct):
+    error: str
+    code: int = 1
+
+
+api = BoltAPI()
+
+
+@api.post("/plans/{pk}/start", response_model={200: PlanRead, 400: PlanError})
+async def start_plan(request, pk: int) -> PlanRead:
+    if pk == 0:
+        raise HTTPException(400, body=PlanError(error="not healthy"), headers={"X-Reason": "health"})
+    if pk == 1:
+        raise NotFound(body=PlanError(error="missing", code=7))
+    if pk == 2:
+        raise HTTPException(400, detail="plain")
+    return PlanRead(id=pk)
+
+
+def test_body_is_encoded_as_is():
+    with TestClient(api) as client:
+        r = client.post("/plans/0/start")
+    assert r.status_code == 400
+    assert r.json() == {"error": "not healthy", "code": 1}
+    assert r.headers["x-reason"] == "health"
+    assert r.headers["content-type"].startswith("application/json")
+
+
+def test_subclass_carries_body():
+    with TestClient(api) as client:
+        r = client.post("/plans/1/start")
+    assert r.status_code == 404
+    assert r.json() == {"error": "missing", "code": 7}
+
+
+def test_no_body_keeps_detail_envelope():
+    with TestClient(api) as client:
+        r = client.post("/plans/2/start")
+    assert r.status_code == 400
+    assert r.json() == {"detail": "plain"}
+
+
+def test_body_attribute_default_is_none():
+    assert HTTPException(400).body is None

--- a/python/tests/test_multi_response.py
+++ b/python/tests/test_multi_response.py
@@ -150,21 +150,22 @@ def test_204_none_produces_empty_body():
 
 
 # ============================================================================
-# 6. Unmapped status code returns 500 (exception caught by dispatch)
+# 6. Unmapped status code is sent as-is (no schema check)
 # ============================================================================
 
 
-def test_unmapped_status_code_returns_500():
-    """Unmapped status code with no ellipsis catch-all returns 500."""
+def test_unmapped_status_code_is_sent_as_is():
+    """Unmapped status code with no ellipsis catch-all encodes the body as-is."""
     api = BoltAPI()
 
     @api.get("/items/{item_id}", response_model={200: OkSchema, 400: ErrorSchema})
     async def get_item(item_id: int):
-        return 999, {"detail": "Unknown"}
+        return 418, {"detail": "Unknown"}
 
     with TestClient(api) as client:
         r = client.get("/items/1")
-        assert r.status_code == 500
+        assert r.status_code == 418
+        assert r.json() == {"detail": "Unknown"}
 
 
 # ============================================================================
@@ -513,12 +514,12 @@ def test_bare_list_multi_response_sync():
 
 
 # ============================================================================
-# Validation failure returns 500
+# Per-status bodies are not validated
 # ============================================================================
 
 
-def test_validation_failure_returns_500():
-    """Data that doesn't match the schema for a status code returns 500."""
+def test_mismatched_body_is_not_validated():
+    """Data that doesn't match the declared schema is still sent as-is."""
     api = BoltAPI()
 
     @api.get("/items/{item_id}", response_model={200: OkSchema, 400: ErrorSchema})
@@ -527,4 +528,5 @@ def test_validation_failure_returns_500():
 
     with TestClient(api) as client:
         r = client.get("/items/1")
-        assert r.status_code == 500
+        assert r.status_code == 200
+        assert r.json() == {"wrong_field": "no id or name"}

--- a/python/tests/test_multi_response_integration.py
+++ b/python/tests/test_multi_response_integration.py
@@ -147,30 +147,31 @@ def test_ellipsis_catch_all():
 
 
 # ============================================================================
-# 7. Unmapped code without catch-all returns 500
+# 7. Unmapped code without catch-all is sent as-is
 # ============================================================================
 
 
-def test_unmapped_code_500():
-    """Unmapped status code without ellipsis catch-all returns 500."""
+def test_unmapped_code_sent_as_is():
+    """Unmapped status code without ellipsis catch-all encodes the body as-is."""
     api = BoltAPI()
 
     @api.get("/items/{item_id}", response_model={200: OkSchema, 400: ErrorSchema})
     async def get_item(item_id: int):
-        return 999, {"detail": "Unknown"}
+        return 418, {"detail": "Unknown"}
 
     with TestClient(api) as client:
         response = client.get("/items/1")
-        assert response.status_code == 500
+        assert response.status_code == 418
+        assert response.json() == {"detail": "Unknown"}
 
 
 # ============================================================================
-# 8. Validation failure returns 500
+# 8. Per-status bodies are not validated
 # ============================================================================
 
 
-def test_validation_failure_500():
-    """Data that doesn't match the schema returns 500."""
+def test_mismatched_body_is_not_validated():
+    """Data that doesn't match the declared schema is still sent as-is."""
     api = BoltAPI()
 
     @api.get("/items/{item_id}", response_model={200: OkSchema, 400: ErrorSchema})
@@ -179,7 +180,8 @@ def test_validation_failure_500():
 
     with TestClient(api) as client:
         response = client.get("/items/1")
-        assert response.status_code == 500
+        assert response.status_code == 200
+        assert response.json() == {"wrong_field": "no id or name"}
 
 
 # ============================================================================

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1400,10 +1400,18 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
 
     // ACCESS_LOG: compiler eliminates this entire block when ACCESS_LOG=false (const generic).
     // When ACCESS_LOG=true, log method/path/status/duration via Django's logger.
+    // The level follows the status, like Django's runserver: 5xx error, 4xx warning, else info.
     if ACCESS_LOG {
         // access_log_start is always Some when ACCESS_LOG=true; unwrap is safe.
         let dur_ms = access_log_start.unwrap().elapsed().as_secs_f64() * 1000.0;
         let status = response.status().as_u16();
+        let level = if status >= 500 {
+            "error"
+        } else if status >= 400 {
+            "warning"
+        } else {
+            "info"
+        };
         // Format OUTSIDE the GIL — only the logger call itself needs Python.
         let msg = format!("{} {} {} {:.1}ms", method, path, status, dur_ms);
         // access_logger is always Some when ACCESS_LOG=true (guaranteed by server.rs startup).
@@ -1412,7 +1420,7 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
                 .access_logger
                 .as_ref()
                 .unwrap()
-                .call_method1(py, "info", (msg,));
+                .call_method1(py, level, (msg,));
         });
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -606,12 +606,14 @@ pub fn start_server(
         // Check Django's logging configuration to determine if access logging is enabled.
         // Uses the standard django.server logger — no extra settings needed.
         // Decision is made once at startup (Granian pattern: zero cost when off).
+        // Gate on WARNING: a logger at WARNING still receives the 4xx/5xx lines,
+        // and Python's own level check drops the INFO lines.
         let (access_log_enabled, access_logger_obj) = (|| -> (bool, Option<Py<PyAny>>) {
             let logging = match py.import("logging") {
                 Ok(m) => m,
                 Err(_) => return (false, None),
             };
-            let info_level: i32 = match logging.getattr("INFO").and_then(|v| v.extract()) {
+            let warning_level: i32 = match logging.getattr("WARNING").and_then(|v| v.extract()) {
                 Ok(v) => v,
                 Err(_) => return (false, None),
             };
@@ -620,7 +622,7 @@ pub fn start_server(
                 Err(_) => return (false, None),
             };
             let enabled = logger
-                .call_method1("isEnabledFor", (info_level,))
+                .call_method1("isEnabledFor", (warning_level,))
                 .and_then(|v| v.extract::<bool>())
                 .unwrap_or(false);
             if enabled {


### PR DESCRIPTION
## Summary

**Typed error bodies**
- `HTTPException(status, body=<Struct>)` sends `body` encoded as-is, with the status and headers from the exception. No `{"detail": ...}` envelope.
- The handler return annotation stays the success type (`-> PlanRead`), so mypy/pyright can check it. `response_model={400: Error}` still documents the schema in OpenAPI.
- Per-status bodies are no longer validated at runtime. A tuple with an unmapped status is sent as-is instead of a 500.
- `_handle_http_exception` now delegates to `http_exception_handler`: one exception-to-wire path. Removes a dead `text/plain` fallback and stops the dispatch path from dropping `extra`.

```python
@api.post("/plans/{pk}/start", response_model={200: Plan, 400: Error})
async def start_plan(request, pk: int) -> Plan:
    if not healthy:
        raise HTTPException(400, body=Error(detail="not healthy"))
    return Plan(id=pk)
```

**Access-log levels**
- The Rust access log on `django.server` now uses ERROR for 5xx, WARNING for 4xx, INFO otherwise (same as Django `runserver`).
- Startup gate is `isEnabledFor(WARNING)` instead of `INFO`, so a logger at WARNING gets the 4xx/5xx lines. When the log is off, the request path has no logging code (const generic, unchanged).

## Tests
- `tests/test_http_exception_body.py` (TestClient) and `tests/integration/test_http_exception_body_server_integration.py` (`server_integration`, async and sync dispatch).
- `tests/integration/test_access_log_levels_server_integration.py` (`server_integration`, explicit `LOGGING` with a file handler).
- Four multi-response tests flipped from "500 on mismatch/unmapped" to "sent as-is".
- Full suite: 2720 passed.

## Docs
- `docs/src/topics/responses.md`: typed error bodies, no validation.
- `docs/src/topics/logging.md`: access-log level table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

Yes. The PR touches the hot request path.

- `src/handler.rs` adds a small status-code branch when access logging is enabled.
- This branch is required for status-based access-log levels.
- `src/server.rs` enables access logging when `django.server` accepts `WARNING`, so 4xx and 5xx responses remain visible.
- The request path skips access-log work when logging is disabled.
- Multi-response dispatch uses a precomputed catch-all lookup.
- This lookup is required to send unmapped statuses without validation.
- No unnecessary work is evident in the summarized changes.

Overall, the hot-path impact is small and directly supports the requested functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->