### PR TITLE
feat(openapi): layered include_in_schema on BoltAPI, views, and routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Layered `include_in_schema`** - The flag now works like Litestar. Set it on `BoltAPI(include_in_schema=False)` to hide every route of that API, on a mounted sub-API, on an `APIView`/`ViewSet` class attribute, in `@api.view(...)`/`@api.viewset(...)`, or on one route. The most specific layer wins. `None` inherits from the outer layer.
 - **Django Debug Toolbar guide** - `docs/src/topics/debug-toolbar.md` shows the setup. The toolbar works on Bolt routes through `django_middleware=[...]` and on mounted Django views. The example project has the setup and a mounted Django view at `/django/missions/`.
 
 ## [0.10.3]

--- a/docs/src/ref/api.md
+++ b/docs/src/ref/api.md
@@ -28,6 +28,7 @@ BoltAPI(
     logging_config=None,       # Custom logging configuration
     compression=None,          # CompressionConfig for response compression
     openapi_config=None,       # OpenAPIConfig for documentation
+    include_in_schema=None,    # OpenAPI visibility default for this API's routes
 )
 ```
 
@@ -43,6 +44,7 @@ BoltAPI(
 | `logging_config` | `LoggingConfig` | `None` | Custom logging configuration |
 | `compression` | `CompressionConfig` | `None` | Response compression settings |
 | `openapi_config` | `OpenAPIConfig` | `None` | Configuration for OpenAPI documentation |
+| `include_in_schema` | `bool` or `None` | `None` | Default OpenAPI visibility for this API's routes. A route, view, or viewset value wins. `None` inherits from the API this one is mounted into |
 
 `middleware` fails fast for unsupported instances. Pass middleware classes (`pass class, not instance`) for global/router lists.
 
@@ -187,7 +189,7 @@ All route decorators accept these options:
 | `tags` | `list[str]` | OpenAPI tags for grouping |
 | `auth` | `list` | Authentication backends |
 | `guards` | `list` | Permission guards |
-| `include_in_schema` | `bool` | Include in OpenAPI docs |
+| `include_in_schema` | `bool` or `None` | Include in OpenAPI docs. `None` inherits from the view class, then from the `BoltAPI` |
 
 ### Class-based view decorators
 

--- a/docs/src/topics/openapi.md
+++ b/docs/src/topics/openapi.md
@@ -379,13 +379,34 @@ async def search(
 
 ## Hiding endpoints
 
-Remove endpoints from the documentation. The server continues to serve them:
+Set `include_in_schema=False` to remove endpoints from the documentation. The
+server continues to serve them. The flag is layered. You can set it on a route,
+on a view class, or on a `BoltAPI`. The most specific layer wins:
 
 ```python
 @api.get("/internal", include_in_schema=False)
 async def internal():
     return {"internal": True}
+
+
+@api.view("/admin", include_in_schema=False)
+class AdminView(APIView):
+    async def get(self):
+        return {}
+
+
+class InternalViewSet(ViewSet):
+    include_in_schema = False  # the class attribute is the middle layer
+    ...
+
+
+# Hide a whole sub-API. A route with include_in_schema=True stays visible.
+internal_api = BoltAPI(include_in_schema=False)
+api.mount("/internal", internal_api)
 ```
+
+The default value at each layer is `None`. `None` inherits from the outer layer.
+The root `BoltAPI` resolves `None` to `True`.
 
 ## Non-JSON responses
 

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -345,6 +345,7 @@ class BoltAPI:
         compression: Any | None = None,
         openapi_config: Any | None = None,
         validate_response: bool = True,
+        include_in_schema: bool | None = None,
         lifespan: Callable | None = None,
     ) -> None:
         """
@@ -375,6 +376,9 @@ class BoltAPI:
                 this argument in production.
             openapi_config: OpenAPI documentation configuration
             validate_response: Default response validation policy for registered routes
+            include_in_schema: Default OpenAPI visibility for the routes of this API.
+                A route, view, or viewset that sets its own value wins. ``None``
+                inherits from the API this one is mounted into. The root defaults to True.
             lifespan: Async context manager factory for startup/shutdown lifecycle.
                 Receives the BoltAPI instance as argument.
         """
@@ -390,6 +394,7 @@ class BoltAPI:
         self.trailing_slash = trailing_slash  # Mode: "strip", "append", or "keep"
         self.namespace = namespace  # Opt-in reverse namespace; see django_bolt.urls
         self._validate_response_default = validate_response
+        self.include_in_schema = include_in_schema
 
         # Build middleware list: Django middleware first, then custom middleware
         self._middleware = []
@@ -549,7 +554,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "GET",
@@ -581,7 +586,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "POST",
@@ -613,7 +618,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "PUT",
@@ -645,7 +650,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "PATCH",
@@ -677,7 +682,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "DELETE",
@@ -709,7 +714,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "HEAD",
@@ -741,7 +746,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "OPTIONS",
@@ -773,7 +778,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
     ):
         return self._route_decorator(
             "QUERY",
@@ -907,6 +912,7 @@ class BoltAPI:
         status_code: int | None = None,
         validate_response: bool | None = None,
         tags: list[str] | None = None,
+        include_in_schema: bool | None = None,
     ):
         """
         Register a class-based view as a decorator.
@@ -958,6 +964,11 @@ class BoltAPI:
                     if method not in available_methods:
                         raise ValueError(f"View class {view_cls.__name__} does not implement method '{method}'")
 
+            # Class attribute is the middle layer: decorator kwarg > class > API.
+            merged_include_in_schema = include_in_schema
+            if merged_include_in_schema is None:
+                merged_include_in_schema = view_cls.include_in_schema
+
             # Register each method
             for method in methods_to_register:
                 method_upper = method.upper()
@@ -1001,6 +1012,7 @@ class BoltAPI:
                     guards=merged_guards,
                     auth=merged_auth,
                     tags=tags,
+                    include_in_schema=merged_include_in_schema,
                 )
 
                 # Apply decorator to register the handler
@@ -1009,7 +1021,13 @@ class BoltAPI:
             # Scan for custom action methods (methods decorated with @action)
             # Note: api.view() doesn't have base path context for @action decorator
             # Custom actions with @action should use api.viewset() instead
-            self._register_custom_actions(view_cls, base_path=None, lookup_field=None, base_name=None)
+            self._register_custom_actions(
+                view_cls,
+                base_path=None,
+                lookup_field=None,
+                base_name=None,
+                include_in_schema=merged_include_in_schema,
+            )
 
             return view_cls
 
@@ -1026,6 +1044,7 @@ class BoltAPI:
         validate_response: bool | None = None,
         lookup_field: str = "pk",
         tags: list[str] | None = None,
+        include_in_schema: bool | None = None,
     ):
         """
         Register a ViewSet with automatic CRUD route generation as a decorator.
@@ -1086,6 +1105,11 @@ class BoltAPI:
             # Reverse-name base for all generated routes. Both an explicit name and
             # the class-name fallback are used verbatim.
             vs_base = name if name is not None else viewset_cls.__name__
+
+            # Class attribute is the middle layer: decorator kwarg > class > API.
+            merged_include_in_schema = include_in_schema
+            if merged_include_in_schema is None:
+                merged_include_in_schema = viewset_cls.include_in_schema
 
             # Define standard action mappings with HTTP-compliant status codes
             # Format: action_name: (method, path, default_status_code)
@@ -1190,6 +1214,7 @@ class BoltAPI:
                     guards=merged_guards,
                     auth=merged_auth,
                     tags=tags,
+                    include_in_schema=merged_include_in_schema,
                 )
                 route_decorator(handler)
 
@@ -1198,6 +1223,7 @@ class BoltAPI:
                 viewset_cls,
                 base_path=path,
                 lookup_field=actual_lookup_field,
+                include_in_schema=merged_include_in_schema,
                 base_name=vs_base,
                 base_name_explicit=name is not None,
             )
@@ -1226,6 +1252,7 @@ class BoltAPI:
         lookup_field: str | None,
         base_name: str | None = None,
         base_name_explicit: bool = False,
+        include_in_schema: bool | None = None,
     ):
         """
         Scan a ViewSet class for custom action methods and register them.
@@ -1364,6 +1391,7 @@ class BoltAPI:
                         tags=attr.tags,
                         summary=attr.summary,
                         description=attr.description,
+                        include_in_schema=include_in_schema,
                     )
                     decorator(custom_action_handler)
 
@@ -1382,7 +1410,7 @@ class BoltAPI:
         summary: str | None = None,
         description: str | None = None,
         response_class: type | None = None,
-        include_in_schema: bool = True,
+        include_in_schema: bool | None = None,
         _name_explicit: bool = True,
         _skip_prefix: bool = False,
         _router_middleware: list[Any] | None = None,
@@ -2957,7 +2985,12 @@ class BoltAPI:
 
             # Copy handler metadata (now keyed by handler_id for performance)
             if handler_id in app._handler_meta:
-                self._handler_meta[new_handler_id] = app._handler_meta[handler_id]
+                meta = app._handler_meta[handler_id]
+                # A route that inherits takes the mounted API's value here, so
+                # the next outer layer sees it as decided (Litestar layering).
+                if meta["include_in_schema"] is None and app.include_in_schema is not None:
+                    meta = {**meta, "include_in_schema": app.include_in_schema}
+                self._handler_meta[new_handler_id] = meta
 
             # Copy middleware metadata (with path updated)
             if handler_id in app._handler_middleware:

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -79,7 +79,7 @@ from .serialization import (
 )
 from .status_codes import HTTP_201_CREATED, HTTP_204_NO_CONTENT
 from .typing import HandlerMetadata, HandlerPattern
-from .views import APIView, ViewSet
+from .views import APIView, ViewSet, _layer
 from .websocket import mark_websocket_handler
 
 Response = ResponseWireV1
@@ -965,9 +965,7 @@ class BoltAPI:
                         raise ValueError(f"View class {view_cls.__name__} does not implement method '{method}'")
 
             # Class attribute is the middle layer: decorator kwarg > class > API.
-            merged_include_in_schema = include_in_schema
-            if merged_include_in_schema is None:
-                merged_include_in_schema = view_cls.include_in_schema
+            merged_include_in_schema = _layer(include_in_schema, view_cls.include_in_schema)
 
             # Register each method
             for method in methods_to_register:
@@ -1107,9 +1105,7 @@ class BoltAPI:
             vs_base = name if name is not None else viewset_cls.__name__
 
             # Class attribute is the middle layer: decorator kwarg > class > API.
-            merged_include_in_schema = include_in_schema
-            if merged_include_in_schema is None:
-                merged_include_in_schema = viewset_cls.include_in_schema
+            merged_include_in_schema = _layer(include_in_schema, viewset_cls.include_in_schema)
 
             # Define standard action mappings with HTTP-compliant status codes
             # Format: action_name: (method, path, default_status_code)
@@ -2985,12 +2981,13 @@ class BoltAPI:
 
             # Copy handler metadata (now keyed by handler_id for performance)
             if handler_id in app._handler_meta:
-                meta = app._handler_meta[handler_id]
                 # A route that inherits takes the mounted API's value here, so
                 # the next outer layer sees it as decided (Litestar layering).
-                if meta["include_in_schema"] is None and app.include_in_schema is not None:
-                    meta = {**meta, "include_in_schema": app.include_in_schema}
-                self._handler_meta[new_handler_id] = meta
+                meta = app._handler_meta[handler_id]
+                self._handler_meta[new_handler_id] = {
+                    **meta,
+                    "include_in_schema": _layer(meta["include_in_schema"], app.include_in_schema),
+                }
 
             # Copy middleware metadata (with path updated)
             if handler_id in app._handler_middleware:

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -23,6 +23,7 @@ from ..responses import (
 )
 from ..serializers.fields import _FieldMarker
 from ..typing import is_msgspec_struct, is_optional, unwrap_optional
+from ..views import _layer
 from .spec import (
     Example,
     OpenAPI,
@@ -266,13 +267,6 @@ def _build_union_examples(response_type: Any) -> dict[str, Example] | None:
 
 class SchemaGenerator:
     """Generate OpenAPI schema from BoltAPI routes."""
-
-    def _hidden(self, meta: dict[str, Any]) -> bool:
-        """Resolve layered ``include_in_schema``: route value, else the API value, else True."""
-        include = meta.get("include_in_schema")
-        if include is None:
-            include = self.api.include_in_schema
-        return include is False
 
     def __init__(self, api: BoltAPI, config: OpenAPIConfig) -> None:
         """Initialize schema generator.
@@ -529,7 +523,7 @@ class SchemaGenerator:
 
             # Get handler metadata
             meta = self.api._handler_meta.get(handler_id, {})
-            if self._hidden(meta):
+            if _layer(meta.get("include_in_schema"), self.api.include_in_schema) is False:
                 continue
 
             if path not in paths:

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -267,6 +267,13 @@ def _build_union_examples(response_type: Any) -> dict[str, Example] | None:
 class SchemaGenerator:
     """Generate OpenAPI schema from BoltAPI routes."""
 
+    def _hidden(self, meta: dict[str, Any]) -> bool:
+        """Resolve layered ``include_in_schema``: route value, else the API value, else True."""
+        include = meta.get("include_in_schema")
+        if include is None:
+            include = self.api.include_in_schema
+        return include is False
+
     def __init__(self, api: BoltAPI, config: OpenAPIConfig) -> None:
         """Initialize schema generator.
 
@@ -522,7 +529,7 @@ class SchemaGenerator:
 
             # Get handler metadata
             meta = self.api._handler_meta.get(handler_id, {})
-            if not meta.get("include_in_schema", True):
+            if self._hidden(meta):
                 continue
 
             if path not in paths:

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -1255,231 +1255,69 @@ class SchemaGenerator:
         return list(tag_objects.values()) if tag_objects else None
 
     def _type_to_schema(self, type_annotation: Any, register_component: bool = False) -> Schema | Reference:
-        """Convert Python type annotation to OpenAPI Schema.
+        """Convert a Python type annotation or msgspec.inspect node to an OpenAPI Schema.
 
         Args:
-            type_annotation: Python type annotation.
+            type_annotation: Python type annotation or ``msgspec.inspect`` node.
             register_component: Whether to register complex types as components.
 
         Returns:
             Schema or Reference object.
         """
-        # Handle None/empty
         if type_annotation is None or type_annotation == inspect._empty:
             return Schema(type="object")
 
-        # Handle msgspec type info objects (IntType, StrType, BoolType, etc.)
-        type_name = type(type_annotation).__name__
+        # msgspec.inspect nodes (Metadata, IntType, StructType, ...) dispatch by
+        # class name; nodes without a handler (AnyType, NoneType, RawType, ...)
+        # are a generic object. Everything else is a ``typing`` annotation.
+        node_cls = type(type_annotation)
+        if node_cls.__module__ == "msgspec.inspect":
+            node_handler = _MSGSPEC_NODE_HANDLERS.get(node_cls.__name__)
+            if node_handler is None:
+                return Schema(type="object")
+            return node_handler(self, type_annotation, register_component)
+        return self._typing_to_schema(type_annotation, register_component)
 
-        # msgspec.inspect wraps an ``Annotated[T, Meta(...)]`` whose Meta carries
-        # informational fields (title/description/examples or an explicit
-        # extra_json_schema) in a ``Metadata`` node: ``.type`` is the underlying
-        # ``*Type`` (StrType/IntType/…) carrying the constraints, and
-        # ``.extra_json_schema`` holds the informational fields. A Meta with
-        # *only* constraints stays a bare ``*Type`` (handled below), but every
-        # documented custom type — Email, PositiveInt, HttpsURL, … i.e. all of
-        # ``serializers.types`` — gets this wrapper. Without unwrapping it here,
-        # those fields fall through every branch to the generic ``object``
-        # fallback and codegen tools (typescript-fetch, openapi-typescript)
-        # emit ``object`` instead of string/integer. (#235)
-        if type_name == "Metadata":
-            base = self._type_to_schema(type_annotation.type, register_component=register_component)
-            extra = getattr(type_annotation, "extra_json_schema", None)
-            # Constraints already live on ``base`` (from the wrapped *Type); only
-            # the docs need merging, and only onto an inline Schema — a $ref to a
-            # component (Struct) carries its own description and can't take siblings.
-            if extra and isinstance(base, Schema):
-                self._apply_json_schema_extra(base, extra)
-            return base
-
-        if hasattr(type_annotation, "__class__") and type_name.endswith("Type"):
-            # Numeric types with constraint support (ge/gt/le/lt/multiple_of)
-            if type_name == "IntType":
-                return self._numeric_type_schema(type_annotation, "integer")
-            if type_name == "FloatType":
-                return self._numeric_type_schema(type_annotation, "number")
-            # String type with constraint support (min_length/max_length/pattern)
-            if type_name == "StrType":
-                return Schema(
-                    **self._schema_kwargs(
-                        type="string",
-                        min_length=type_annotation.min_length,
-                        max_length=type_annotation.max_length,
-                        pattern=type_annotation.pattern,
-                    )
-                )
-            # Types without constraints — static map
-            msgspec_type_map = {
-                "BoolType": Schema(type="boolean"),
-                "BytesType": Schema(type="string", format="binary"),
-                "DateTimeType": Schema(type="string", format="date-time"),
-                "DateType": Schema(type="string", format="date"),
-                "TimeType": Schema(type="string", format="time"),
-                "UUIDType": Schema(type="string", format="uuid"),
-            }
-            if type_name in msgspec_type_map:
-                return msgspec_type_map[type_name]
-            # For list/array types from msgspec
-            if type_name == "StructType":
-                # Nested struct from msgspec.inspect — always register as a
-                # component so self-referential types emit a $ref instead of
-                # recursing infinitely.  The sentinel in
-                # _struct_to_component_schema guards against re-entry.
-                return self._struct_to_component_schema(type_annotation.cls)
-            if type_name == "UnionType" and hasattr(type_annotation, "types"):
-                # msgspec.inspect UnionType — the .types attr distinguishes
-                # this from Python's built-in types.UnionType (which uses
-                # .__args__ instead).
-                #
-                # String comparison: msgspec.inspect.NoneType is not the
-                # same object as builtins.NoneType.
-                types = list(type_annotation.types)
-                non_none_types = [t for t in types if type(t).__name__ != "NoneType"]
-                has_none = len(non_none_types) != len(types)
-
-                if not non_none_types:
-                    # `None`-only union (rare; e.g. Optional[NoneType])
-                    return Schema(type="null") if has_none else Schema(type="object")
-
-                inner_schemas = [self._type_to_schema(t, register_component=register_component) for t in non_none_types]
-                return self._union_schema(
-                    inner_schemas,
-                    has_none=has_none,
-                    tagged=_is_tagged_struct_union(non_none_types),
-                )
-            if type_name == "ListType":
-                item_type = getattr(type_annotation, "item_type", None)
-                if item_type:
-                    item_schema = self._type_to_schema(item_type, register_component=register_component)
-                    return Schema(type="array", items=item_schema)
-                return Schema(type="array", items=Schema(type="object"))
-            # For dict types from msgspec — recurse into the *value* type via
-            # _mapping_schema. An untyped value (bare dict / dict[str, Any],
-            # which msgspec models as AnyType) stays additionalProperties: true.
-            if type_name == "DictType":
-                value_type = getattr(type_annotation, "value_type", None)
-                typed = value_type is not None and type(value_type).__name__ != "AnyType"
-                return self._mapping_schema(
-                    self._type_to_schema(value_type, register_component=register_component) if typed else None
-                )
-            # For enum types from msgspec (EnumType for plain enums,
-            # CustomType for Django TextChoices/IntegerChoices which use
-            # a metaclass that msgspec doesn't recognise as a standard enum)
-            if (
-                type_name in ("EnumType", "CustomType")
-                and hasattr(type_annotation, "cls")
-                and issubclass(type_annotation.cls, enum.Enum)
-            ):
-                # Named enum classes (enum.Enum / msgspec EnumType / Django
-                # TextChoices/IntegerChoices) are promoted to named components +
-                # $ref in component contexts (request/response bodies), parallel
-                # to how Structs are registered — so consumers get a reusable
-                # type and the enum's docstring survives as `description`. In
-                # inline contexts (query params) they stay inline. Anonymous
-                # `Literal[...]` unions (LiteralType, below) always stay inline.
-                return self._enum_schema(type_annotation.cls, register_component=register_component)
-            # msgspec.inspect.type_info represents Literal fields on Structs as
-            # LiteralType, so keep this branch alongside the bare typing.Literal
-            # branch below.
-            if type_name == "LiteralType":
-                return self._enum_values_schema(type_annotation.values)
-
-        # Unwrap Optional
-        origin = get_origin(type_annotation)
-        args = get_args(type_annotation)
-
-        if origin is Annotated:
-            # A documented custom type (e.g. ``Email = Annotated[str, Meta(...)]``)
-            # used directly as a response model — bare (``-> Email``) or nested
-            # (``-> list[Email]``) — reaches here as a raw typing.Annotated still
-            # carrying its msgspec Meta. Normalize it through msgspec.inspect so it
-            # renders identically to the same type used as a Struct field (the
-            # Metadata branch above then applies constraints + docs). Param markers
-            # like Query()/Header() are not msgspec.Meta, so ``Annotated[T, Query()]``
-            # still falls through to the plain unwrap below. (#235)
+    def _typing_to_schema(self, type_annotation: Any, register_component: bool) -> Schema | Reference:
+        """Convert a raw ``typing`` annotation (not a msgspec.inspect node)."""
+        # A documented custom type (e.g. ``Email = Annotated[str, Meta(...)]``)
+        # used directly as a response model — bare or nested (``list[Email]``) —
+        # still carries its msgspec Meta. Normalize it through msgspec.inspect so
+        # it renders identically to the same type used as a Struct field. Param
+        # markers like Query() are not msgspec.Meta, so ``Annotated[T, Query()]``
+        # unwraps to ``T`` below. (#235)
+        if get_origin(type_annotation) is Annotated:
+            args = get_args(type_annotation)
             if any(isinstance(m, msgspec.Meta) for m in args[1:]):
                 return self._type_to_schema(
-                    msgspec.inspect.type_info(type_annotation),
-                    register_component=register_component,
+                    msgspec.inspect.type_info(type_annotation), register_component=register_component
                 )
-            # Unwrap Annotated[T, ...]
             type_annotation = args[0]
-            origin = get_origin(type_annotation)
-            args = get_args(type_annotation)
 
-        # Handle Optional[T] -> T (single non-None arg only; multi-arm unions
-        # like `A | B | None` fall through to the Union branch below so every
-        # arm is preserved).
+        # Optional[T] -> T (single non-None arg only; multi-arm unions like
+        # ``A | B | None`` go to _union_schema so every arm is preserved).
         if is_optional(type_annotation):
-            non_none_args = [arg for arg in args if arg is not type(None)]
+            non_none_args = [arg for arg in get_args(type_annotation) if arg is not type(None)]
             if len(non_none_args) == 1:
                 type_annotation = non_none_args[0]
-                origin = get_origin(type_annotation)
-                args = get_args(type_annotation)
 
-        # Handle UploadFile — list[UploadFile] flows through the list branch
-        # below and recurses back into this check for the item type.
+        origin_handler = _TYPING_ORIGIN_HANDLERS.get(get_origin(type_annotation))
+        if origin_handler is not None:
+            return origin_handler(self, get_args(type_annotation), register_component)
+
         if type_annotation is UploadFile:
             return Schema(type="string", format="binary")
-
-        # Handle msgspec.Struct — bare or parametrized (``Page[UserRead]``, keyed
-        # and named per parametrization like msgspec: ``Page_UserRead_``).
+        # Bare or parametrized Struct (``Page[UserRead]`` is keyed per parametrization).
         if _struct_origin(type_annotation) is not None:
             if register_component:
                 return self._struct_to_component_schema(type_annotation)
-            else:
-                return self._struct_to_schema(type_annotation)
-
-        # Handle bare enum classes (e.g. ``-> GateReason`` or ``list[GateReason]``).
-        # A named enum used as a Struct *field* reaches the msgspec.inspect
-        # EnumType/CustomType branch above; used directly as a (nested) response
-        # model it arrives here as a raw enum class via the typing path. Same
-        # promote-or-inline policy as the field path, via _enum_schema. (#246)
+            return self._struct_to_schema(type_annotation)
+        # Bare enum classes (``-> GateReason``): same promote-or-inline policy
+        # as the msgspec EnumType path. (#246)
         if isinstance(type_annotation, type) and issubclass(type_annotation, enum.Enum):
             return self._enum_schema(type_annotation, register_component=register_component)
-
-        if origin is Union or origin is UnionType:
-            non_none_args = [arg for arg in args if arg is not type(None)]
-            has_none = len(non_none_args) != len(args)
-            inner = [self._type_to_schema(arg, register_component=register_component) for arg in non_none_args]
-            return self._union_schema(inner, has_none=has_none, tagged=_is_tagged_struct_union(non_none_args))
-
-        # Handle list
-        if origin is list:
-            item_type = args[0] if args else Any
-            item_schema = self._type_to_schema(item_type, register_component=register_component)
-            return Schema(type="array", items=item_schema)
-
-        # Handle dict — recurse into the value type V of dict[K, V] via
-        # _mapping_schema. Bare dict[K] without a value type or dict[str, Any]
-        # stays additionalProperties: true (no value type to describe).
-        if origin is dict:
-            value_type = args[1] if len(args) == 2 else None
-            typed = value_type is not None and value_type is not Any
-            return self._mapping_schema(
-                self._type_to_schema(value_type, register_component=register_component) if typed else None
-            )
-
-        # Bare typing.Literal annotations don't come through
-        # msgspec.inspect.type_info, so they need their own path here.
-        if origin is Literal:
-            return self._enum_values_schema(args)
-
-        # Handle primitive types
-        type_map = {
-            str: Schema(type="string"),
-            int: Schema(type="integer"),
-            float: Schema(type="number"),
-            bool: Schema(type="boolean"),
-            bytes: Schema(type="string", format="binary"),
-        }
-
-        for py_type, schema in type_map.items():
-            if type_annotation == py_type:
-                return schema
-
-        # Default to generic object
-        return Schema(type="object")
+        primitive = _PRIMITIVE_SCHEMAS.get(type_annotation)
+        return Schema(**primitive) if primitive is not None else Schema(type="object")
 
     def _struct_to_schema(self, struct_type: type, *, register_component: bool = False) -> Schema:
         """Convert msgspec.Struct to inline OpenAPI Schema.
@@ -1643,3 +1481,133 @@ class SchemaGenerator:
         for name, cls in names.items():
             self._component_ref[cls].ref = f"#/components/schemas/{name}"
             self.schemas[name] = self._component_schema[cls]
+
+
+# --- _type_to_schema dispatch tables ---------------------------------------
+#
+# Handlers receive ``(generator, node_or_args, register_component)``. The
+# msgspec table is keyed by the ``msgspec.inspect`` node class name; the typing
+# table is keyed by ``get_origin(annotation)`` and receives ``get_args``.
+
+
+def _node_metadata(gen: SchemaGenerator, node: Any, register: bool) -> Schema | Reference:
+    # ``Annotated[T, Meta(...)]`` with informational fields (title/description/
+    # examples/extra_json_schema) arrives as a ``Metadata`` wrapper: ``.type`` is
+    # the constrained ``*Type``; ``.extra_json_schema`` holds the docs. Every
+    # documented custom type in ``serializers.types`` takes this path. (#235)
+    base = gen._type_to_schema(node.type, register_component=register)
+    extra = getattr(node, "extra_json_schema", None)
+    # Constraints already live on ``base``; docs only merge onto an inline
+    # Schema — a $ref to a component cannot take siblings.
+    if extra and isinstance(base, Schema):
+        gen._apply_json_schema_extra(base, extra)
+    return base
+
+
+def _node_str(gen: SchemaGenerator, node: Any, register: bool) -> Schema:
+    return Schema(
+        **gen._schema_kwargs(
+            type="string", min_length=node.min_length, max_length=node.max_length, pattern=node.pattern
+        )
+    )
+
+
+def _node_struct(gen: SchemaGenerator, node: Any, register: bool) -> Schema | Reference:
+    # Always a component so self-referential types emit a $ref instead of
+    # recursing forever; _struct_to_component_schema guards re-entry.
+    return gen._struct_to_component_schema(node.cls)
+
+
+def _node_union(gen: SchemaGenerator, node: Any, register: bool) -> Schema | Reference:
+    # String comparison: msgspec.inspect.NoneType is not builtins.NoneType.
+    types = list(node.types)
+    non_none = [t for t in types if type(t).__name__ != "NoneType"]
+    has_none = len(non_none) != len(types)
+    if not non_none:
+        return Schema(type="null") if has_none else Schema(type="object")
+    inner = [gen._type_to_schema(t, register_component=register) for t in non_none]
+    return gen._union_schema(inner, has_none=has_none, tagged=_is_tagged_struct_union(non_none))
+
+
+def _node_list(gen: SchemaGenerator, node: Any, register: bool) -> Schema:
+    item_type = getattr(node, "item_type", None)
+    if item_type:
+        return Schema(type="array", items=gen._type_to_schema(item_type, register_component=register))
+    return Schema(type="array", items=Schema(type="object"))
+
+
+def _node_dict(gen: SchemaGenerator, node: Any, register: bool) -> Schema:
+    # An untyped value (bare dict / dict[str, Any] -> AnyType) stays
+    # additionalProperties: true.
+    value_type = getattr(node, "value_type", None)
+    typed = value_type is not None and type(value_type).__name__ != "AnyType"
+    return gen._mapping_schema(gen._type_to_schema(value_type, register_component=register) if typed else None)
+
+
+def _node_enum(gen: SchemaGenerator, node: Any, register: bool) -> Schema | Reference:
+    # EnumType for plain enums; CustomType for Django TextChoices/IntegerChoices
+    # (a metaclass msgspec does not see as a standard enum). Named enums become
+    # components + $ref in body contexts and stay inline for params; anonymous
+    # ``Literal[...]`` (LiteralType) always stays inline.
+    cls = getattr(node, "cls", None)
+    if cls is not None and issubclass(cls, enum.Enum):
+        return gen._enum_schema(cls, register_component=register)
+    return Schema(type="object")
+
+
+_MSGSPEC_NODE_HANDLERS: dict[str, Callable[[SchemaGenerator, Any, bool], Schema | Reference]] = {
+    "Metadata": _node_metadata,
+    "IntType": lambda gen, node, _r: gen._numeric_type_schema(node, "integer"),
+    "FloatType": lambda gen, node, _r: gen._numeric_type_schema(node, "number"),
+    "StrType": _node_str,
+    "BoolType": lambda _g, _n, _r: Schema(type="boolean"),
+    "BytesType": lambda _g, _n, _r: Schema(type="string", format="binary"),
+    "DateTimeType": lambda _g, _n, _r: Schema(type="string", format="date-time"),
+    "DateType": lambda _g, _n, _r: Schema(type="string", format="date"),
+    "TimeType": lambda _g, _n, _r: Schema(type="string", format="time"),
+    "UUIDType": lambda _g, _n, _r: Schema(type="string", format="uuid"),
+    "StructType": _node_struct,
+    "UnionType": _node_union,
+    "ListType": _node_list,
+    "DictType": _node_dict,
+    "EnumType": _node_enum,
+    "CustomType": _node_enum,
+    "LiteralType": lambda gen, node, _r: gen._enum_values_schema(node.values),
+}
+
+
+def _origin_union(gen: SchemaGenerator, args: tuple[Any, ...], register: bool) -> Schema | Reference:
+    non_none = [arg for arg in args if arg is not type(None)]
+    inner = [gen._type_to_schema(arg, register_component=register) for arg in non_none]
+    return gen._union_schema(inner, has_none=len(non_none) != len(args), tagged=_is_tagged_struct_union(non_none))
+
+
+def _origin_list(gen: SchemaGenerator, args: tuple[Any, ...], register: bool) -> Schema:
+    item_type = args[0] if args else Any
+    return Schema(type="array", items=gen._type_to_schema(item_type, register_component=register))
+
+
+def _origin_dict(gen: SchemaGenerator, args: tuple[Any, ...], register: bool) -> Schema:
+    # dict[K] without a value type or dict[str, Any] stays additionalProperties: true.
+    value_type = args[1] if len(args) == 2 else None
+    typed = value_type is not None and value_type is not Any
+    return gen._mapping_schema(gen._type_to_schema(value_type, register_component=register) if typed else None)
+
+
+_TYPING_ORIGIN_HANDLERS: dict[Any, Callable[[SchemaGenerator, tuple[Any, ...], bool], Schema | Reference]] = {
+    Union: _origin_union,
+    UnionType: _origin_union,
+    list: _origin_list,
+    dict: _origin_dict,
+    # Bare typing.Literal does not go through msgspec.inspect.type_info.
+    Literal: lambda gen, args, _r: gen._enum_values_schema(args),
+}
+
+# Kwargs, not Schema instances: callers may mutate the returned Schema.
+_PRIMITIVE_SCHEMAS: dict[Any, dict[str, str]] = {
+    str: {"type": "string"},
+    int: {"type": "integer"},
+    float: {"type": "number"},
+    bool: {"type": "boolean"},
+    bytes: {"type": "string", "format": "binary"},
+}

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -48,6 +48,7 @@ class APIView:
     auth: list[Any] | None = None
     status_code: int | None = None
     validate_response: bool | None = None
+    include_in_schema: bool | None = None
 
     def __init__(self, **kwargs):
         """

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -30,6 +30,11 @@ from .request import Request
 from .serializers.base import Serializer
 
 
+def _layer(value: bool | None, outer: bool | None) -> bool | None:
+    """Return ``value`` when it is set, else the next outer layer's value."""
+    return outer if value is None else value
+
+
 class APIView:
     """
     Base class for class-based views in Django-Bolt.

--- a/python/tests/integration/apps/include_in_schema_layers.py
+++ b/python/tests/integration/apps/include_in_schema_layers.py
@@ -1,0 +1,51 @@
+"""App under test for layered ``include_in_schema``.
+
+A hidden sub-API, a hidden view class, and a hidden route. One route in the
+hidden sub-API opts back in. All routes are still served.
+"""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI
+from django_bolt.views import APIView
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/public")
+async def public():
+    return {"public": True}
+
+
+@api.get("/route-hidden", include_in_schema=False)
+async def route_hidden():
+    return {"hidden": "route"}
+
+
+@api.view("/view-hidden")
+class HiddenView(APIView):
+    include_in_schema = False
+
+    async def get(self, request):
+        return {"hidden": "view"}
+
+
+internal = BoltAPI(include_in_schema=False)
+
+
+@internal.get("/secret")
+async def secret():
+    return {"hidden": "api"}
+
+
+@internal.get("/shown", include_in_schema=True)
+async def shown():
+    return {"shown": True}
+
+
+api.mount("/internal", internal)

--- a/python/tests/integration/test_include_in_schema_layers_server_integration.py
+++ b/python/tests/integration/test_include_in_schema_layers_server_integration.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from django_bolt.openapi import OpenAPIConfig
+from django_bolt.openapi.schema_generator import SchemaGenerator
+from django_bolt.testing import TestClient
+
+from .apps import app_module, include_in_schema_layers
+
+HIDDEN = ("/route-hidden", "/view-hidden", "/internal/secret")
+SHOWN = ("/public", "/internal/shown")
+
+
+@pytest.mark.server_integration
+def test_layered_include_in_schema_over_real_server(make_server_project):
+    project = make_server_project(api_module=app_module("include_in_schema_layers"))
+
+    with project.start() as server:
+        spec = server.get("/docs/openapi.json").json()
+        served = {path: server.get(path).status_code for path in HIDDEN + SHOWN}
+
+    paths = set(spec["paths"])
+    assert set(SHOWN) <= paths
+    assert not paths & set(HIDDEN)
+    assert served == dict.fromkeys(HIDDEN + SHOWN, 200)
+
+
+def test_layered_include_in_schema_in_process():
+    """The `/docs` routes only exist under `runbolt`; read the schema directly here."""
+    api = include_in_schema_layers.api
+    paths = set(SchemaGenerator(api, OpenAPIConfig(title="t", version="1")).generate().to_schema()["paths"])
+    with TestClient(api) as client:
+        served = {path: client.get(path).status_code for path in HIDDEN + SHOWN}
+
+    assert set(SHOWN) <= paths
+    assert not paths & set(HIDDEN)
+    assert served == dict.fromkeys(HIDDEN + SHOWN, 200)

--- a/python/tests/test_include_in_schema_layers.py
+++ b/python/tests/test_include_in_schema_layers.py
@@ -1,0 +1,98 @@
+"""Layered ``include_in_schema`` (Litestar style): app > class > route.
+
+The most specific layer wins. ``None`` means "inherit from the outer layer".
+"""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI
+from django_bolt.decorators import action
+from django_bolt.openapi import OpenAPIConfig
+from django_bolt.openapi.schema_generator import SchemaGenerator
+from django_bolt.testing import TestClient
+from django_bolt.views import APIView, ViewSet
+
+
+def _paths(api: BoltAPI) -> set[str]:
+    config = OpenAPIConfig(title="t", version="1")
+    return set(SchemaGenerator(api, config).generate().to_schema()["paths"])
+
+
+def test_api_include_in_schema_false_hides_every_route_but_serves_them():
+    api = BoltAPI(include_in_schema=False)
+
+    @api.get("/a")
+    async def a():
+        return {"a": 1}
+
+    @api.get("/b", include_in_schema=True)
+    async def b():
+        return {"b": 1}
+
+    assert _paths(api) == {"/b"}
+    with TestClient(api) as client:
+        assert client.get("/a").json() == {"a": 1}
+
+
+def test_mounted_api_inherits_and_overrides():
+    hidden = BoltAPI(include_in_schema=False)
+
+    @hidden.get("/x")
+    async def x():
+        return {}
+
+    @hidden.get("/shown", include_in_schema=True)
+    async def shown():
+        return {}
+
+    inherit = BoltAPI()
+
+    @inherit.get("/y")
+    async def y():
+        return {}
+
+    parent = BoltAPI()
+    parent.mount("/hidden", hidden)
+    parent.mount("/inherit", inherit)
+    assert _paths(parent) == {"/hidden/shown", "/inherit/y"}
+
+    hidden_parent = BoltAPI(include_in_schema=False)
+    hidden_parent.mount("/inherit", inherit)
+    hidden_parent.mount("/hidden", hidden)
+    assert _paths(hidden_parent) == {"/hidden/shown"}
+
+
+def test_view_class_attribute_and_decorator_kwarg():
+    api = BoltAPI()
+
+    @api.view("/cls")
+    class HiddenView(APIView):
+        include_in_schema = False
+
+        async def get(self):
+            return {}
+
+    @api.view("/kw", include_in_schema=True)
+    class OverriddenView(APIView):
+        include_in_schema = False
+
+        async def get(self):
+            return {}
+
+    @api.viewset("/vs")
+    class HiddenViewSet(ViewSet):
+        include_in_schema = False
+
+        async def list(self):
+            return []
+
+        @action(detail=False, methods=["GET"])
+        async def custom(self):
+            return {}
+
+    @api.viewset("/vs2", include_in_schema=False)
+    class KwViewSet(ViewSet):
+        async def list(self):
+            return []
+
+    assert _paths(api) == {"/kw"}

--- a/python/tests/test_include_in_schema_layers.py
+++ b/python/tests/test_include_in_schema_layers.py
@@ -69,30 +69,30 @@ def test_view_class_attribute_and_decorator_kwarg():
     class HiddenView(APIView):
         include_in_schema = False
 
-        async def get(self):
+        async def get(self, request):
             return {}
 
     @api.view("/kw", include_in_schema=True)
     class OverriddenView(APIView):
         include_in_schema = False
 
-        async def get(self):
+        async def get(self, request):
             return {}
 
     @api.viewset("/vs")
     class HiddenViewSet(ViewSet):
         include_in_schema = False
 
-        async def list(self):
+        async def list(self, request):
             return []
 
         @action(detail=False, methods=["GET"])
-        async def custom(self):
+        async def custom(self, request):
             return {}
 
     @api.viewset("/vs2", include_in_schema=False)
     class KwViewSet(ViewSet):
-        async def list(self):
+        async def list(self, request):
             return []
 
     assert _paths(api) == {"/kw"}


### PR DESCRIPTION
## Summary

`include_in_schema` is now layered, the same as Litestar. Set it on a `BoltAPI`, on a mounted sub-API, on an `APIView`/`ViewSet` class attribute, in `@api.view(...)`/`@api.viewset(...)`, or on one route. The most specific layer wins. `None` inherits from the outer layer. The root `BoltAPI` resolves `None` to `True`.

```python
internal = BoltAPI(include_in_schema=False)

@internal.get("/secret")            # hidden
async def secret(): ...

@internal.get("/shown", include_in_schema=True)   # visible again
async def shown(): ...

api.mount("/internal", internal)
```

Follows up on the `include_in_schema` bullet in #294.

## Changes

- `BoltAPI(include_in_schema: bool | None = None)`; route decorators default to `None` (was `True`).
- `APIView.include_in_schema` class attribute; `@api.view()`/`@api.viewset()` kwarg overrides it and flows to `@action` routes.
- `mount()` stamps the child API's value onto routes that inherit, so nested mounts chain.
- `SchemaGenerator._hidden()` resolves route value, then API value, then `True`.
- Docs: `topics/openapi.md` hiding section, `ref/api.md` tables. `CHANGELOG.md` entry.

## Tests

- `tests/test_include_in_schema_layers.py`: API level, mount inherit/override (incl. hidden parent), view/viewset class attribute vs decorator kwarg.
- `tests/integration/test_include_in_schema_layers_server_integration.py`: real `runbolt` fetches `/docs/openapi.json`; hidden routes are absent and still served 200. Plus an in-process variant.

Existing `include_in_schema` tests in `test_openapi_codegen_gaps.py` pass unchanged.