### PR TITLE
Fix async user getter for Bolt authentication

### DIFF
--- a/crates/bolt-core/src/request.rs
+++ b/crates/bolt-core/src/request.rs
@@ -352,8 +352,8 @@ impl PyRequest {
     ///
     /// Returns:
     ///     Async callable that returns the user when awaited.
-    ///     If Django middleware is not configured, returns a callable that
-    ///     returns AnonymousUser (matching Django's behavior).
+    ///     Otherwise, returns a callable for the Bolt user, or AnonymousUser
+    ///     if no user is set.
     #[getter]
     fn auser<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
         // Get "auser" from state dict (set by Django middleware adapter)
@@ -362,11 +362,11 @@ impl PyRequest {
         match state_dict.get_item("auser") {
             Ok(Some(auser)) => Ok(auser.unbind()),
             _ => {
-                // Return async callable that returns AnonymousUser
-                // This matches Django's behavior when AuthenticationMiddleware isn't configured
+                // Share the Bolt user when no middleware provides an async getter.
                 let django_bolt_module = py.import("django_bolt.auth.anonymous")?;
                 let auser_fallback = django_bolt_module.getattr("auser_fallback")?;
-                Ok(auser_fallback.unbind())
+                let partial = py.import("functools")?.getattr("partial")?;
+                Ok(partial.call1((auser_fallback, self.user(py)))?.unbind())
             }
         }
     }

--- a/python/django_bolt/auth/anonymous.py
+++ b/python/django_bolt/auth/anonymous.py
@@ -1,28 +1,21 @@
 """
-Anonymous user fallback for when Django middleware is not configured.
-
-This module provides the auser_fallback async function that returns
-AnonymousUser, matching Django's behavior when AuthenticationMiddleware
-is not configured.
+Async user fallback for requests without Django authentication middleware.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from django.contrib.auth.models import AnonymousUser
 
 
-async def auser_fallback() -> AnonymousUser:
+async def auser_fallback(user: Any = None) -> Any:
     """
-    Async fallback that returns AnonymousUser.
+    Return the Bolt user, or an anonymous user if no user is set.
 
-    This is used when Django's AuthenticationMiddleware is not configured,
-    ensuring that `await request.auser()` always returns a valid user object
-    (either the authenticated user or AnonymousUser).
-
-    Returns:
-        AnonymousUser instance
+    Keep the same lazy user object as request.user to share its cached result.
     """
-    return AnonymousUser()
+    return user if user is not None else AnonymousUser()
 
 
 __all__ = ["auser_fallback"]

--- a/python/tests/test_request_user.py
+++ b/python/tests/test_request_user.py
@@ -119,6 +119,44 @@ def custom_auth_api():
 class TestJWTUserLoading:
     """Test request.user loading with JWT authentication."""
 
+    @pytest.mark.django_db(transaction=True)
+    def test_auser_returns_jwt_user_without_django_middleware(self):
+        """Both getters return the JWT user when Django middleware is absent."""
+        api = BoltAPI(django_middleware=[])
+
+        @api.get("/async-me", auth=[JWTAuthentication(secret="test-secret")], guards=[IsAuthenticated()])
+        async def get_async_me(request):
+            user = await request.auser()
+            again = await request.auser()
+            return {
+                "username": user.username,
+                "user_id": user.pk,
+                "same_user": user is request.user and again is user,
+            }
+
+        user = User.objects.create(username="async_jwt_user")
+        token = create_jwt_token(user_id=str(user.pk))
+        with TestClient(api) as client:
+            response = client.get("/async-me", headers={"Authorization": f"Bearer {token}"})
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {"username": user.username, "user_id": user.pk, "same_user": True}
+
+    def test_auser_returns_anonymous_without_authentication(self):
+        """The async getter still returns an anonymous user without authentication."""
+        api = BoltAPI(django_middleware=[])
+
+        @api.get("/async-public")
+        async def get_async_public(request):
+            user = await request.auser()
+            return {"is_anonymous": user.is_anonymous, "is_authenticated": user.is_authenticated}
+
+        with TestClient(api) as client:
+            response = client.get("/async-public")
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {"is_anonymous": True, "is_authenticated": False}
+
     @pytest.mark.django_db(transaction=True)  # Use real database transaction
     def test_authenticated_request_has_user(self, jwt_api):
         """Test that authenticated request with existing user returns 200."""


### PR DESCRIPTION
When JWT authentication succeeds without Django authentication middleware, `await request.auser()` returns `AnonymousUser` while `request.user` returns the authenticated user. Make the async fallback share the Bolt user and its cached result, while preserving middleware-provided getters and anonymous access.

Fixes #328

## How was this tested?

- Added regression tests for JWT user access, repeated async getter calls, and unauthenticated access.
- Confirmed the JWT regression fails before the fix and when the old fallback behavior is restored.
- All 93 tests passed in `test_request_user.py`, `test_session_auth.py`, and `test_django_middleware_integration.py`.
- Library lint, changed Python file formatting, Rust formatting, and `git diff --check` passed.
- Rebuilt the Rust extension with `maturin develop --skip-install --offline`. The standard build command could not fetch a dependency in the sandbox.
- The full Python suite and a clean rebuild were not run.

## Performance consideration

The fallback creates a partial only when code accesses `request.auser` without a middleware-provided getter. It reuses the existing lazy user object and adds no separate user query or work to dispatch, serialization, or routing. No benchmark was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

Yes. `request.auser` is on the request access path.

When Django authentication middleware is absent, each `request.auser` access:

- Imports or retrieves `django_bolt.auth.anonymous`.
- Retrieves `auser_fallback`.
- Retrieves `functools.partial`.
- Creates a new partial bound to `self.user(py)`.

This adds Python object and lookup overhead. Repeated accesses recreate the partial because the fallback getter is not cached.

The work is required to make `await request.auser()` return the Bolt-authenticated user. It does not perform database access or repeated authentication, and it preserves middleware-provided getters.

The overhead is small, but caching the fallback callable would avoid repeated imports, attribute lookups, and partial allocations on this path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->