### PR TITLE
Fix blank ReDoc page caused by missing CDN bundle

### DIFF
--- a/python/django_bolt/openapi/plugins.py
+++ b/python/django_bolt/openapi/plugins.py
@@ -212,7 +212,7 @@ class RedocRenderPlugin(OpenAPIRenderPlugin):
     def __init__(
         self,
         *,
-        version: str = "next",
+        version: str = "2.5.3",
         js_url: str | None = None,
         google_fonts: bool = True,
         path: str | list[str] = "/redoc",

--- a/python/tests/test_openapi_docs.py
+++ b/python/tests/test_openapi_docs.py
@@ -11,12 +11,13 @@ from typing import Annotated
 
 import jwt
 import msgspec
+import pytest
 from django.contrib.admin.views.decorators import staff_member_required
 
 from django_bolt import BoltAPI
 from django_bolt.auth import APIKeyAuthentication, IsAuthenticated, JWTAuthentication
 from django_bolt.datastructures import UploadFile
-from django_bolt.openapi import OpenAPIConfig, SwaggerRenderPlugin
+from django_bolt.openapi import OpenAPIConfig, RedocRenderPlugin, SwaggerRenderPlugin
 from django_bolt.openapi.spec import Components, SecurityScheme
 from django_bolt.params import File, Form
 from django_bolt.serializers import Serializer, field
@@ -105,6 +106,35 @@ def test_swagger_ui_endpoint():
         # Should contain Swagger UI indicators
         html = response.text
         assert "swagger" in html.lower() or "openapi" in html.lower()
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_url"),
+    [
+        ({}, "https://cdn.jsdelivr.net/npm/redoc@2.5.3/bundles/redoc.standalone.js"),
+        ({"version": "2.5.1"}, "https://cdn.jsdelivr.net/npm/redoc@2.5.1/bundles/redoc.standalone.js"),
+        ({"version": "2.5.1", "js_url": "/static/redoc.js"}, "/static/redoc.js"),
+    ],
+)
+def test_redoc_endpoint_uses_available_bundle(options, expected_url):
+    """Use a published bundle by default and preserve explicit URL overrides."""
+    api = BoltAPI(
+        openapi_config=OpenAPIConfig(title="ReDoc API", version="1.0.0", render_plugins=[RedocRenderPlugin(**options)])
+    )
+
+    @api.get("/items")
+    async def get_items():
+        return []
+
+    api._register_openapi_routes()
+    with TestClient(api) as client:
+        response = client.get("/docs/redoc/")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert f'<script src="{expected_url}" crossorigin></script>' in response.text
+    assert "Redoc.init(" in response.text
+    assert '"/items"' in response.text
 
 
 def test_swagger_ui_supports_openapi_3_2_query_specs():


### PR DESCRIPTION
The ReDoc page loads a JavaScript bundle from `redoc@next`, which returns HTTP 404 and leaves the documentation blank. Pin the default to the published `2.5.3` release so `Redoc.init` can load the documentation. Explicit `version` and `js_url` overrides still work.

## How was this tested?

- Verified the old CDN URL returns `404 text/plain` and the pinned URL returns `200 application/javascript`.
- Added HTTP endpoint tests for the default bundle, custom versions, and custom URLs.
- Confirmed the default regression fails before the fix and after temporarily reverting it.
- All 18 OpenAPI documentation tests passed. Library lint, changed-file formatting, and `git diff --check` passed.
- The full Python suite and browser rendering were not run. No Rust code changed.

## Performance consideration

Only the default documentation asset version changes. There is no change to request dispatch, serialization, or routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

The PR does not touch the general application hot request path.

It changes only the default `RedocRenderPlugin` version from `next` to `2.5.3`. This affects ReDoc documentation responses only.

The change adds no per-request computation, network call, or other runtime work. The `/redoc` endpoint still performs the required work of rendering documentation HTML with a valid CDN bundle.

The change is safe for application request performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->