### PR TITLE
Fix OpenAPI status codes for unannotated handlers

### DIFF
--- a/docs/src/topics/responses.md
+++ b/docs/src/topics/responses.md
@@ -532,6 +532,8 @@ async def create_user():
     return {"id": 1, "username": "john"}
 ```
 
+OpenAPI documents this status code even when the handler has no response annotation.
+
 ## Returning strings and bytes
 
 Returning a string creates a plain text response:
@@ -557,7 +559,7 @@ For 204 No Content responses:
 ```python
 from django_bolt import Response
 
-@api.delete("/items/{item_id}")
+@api.delete("/items/{item_id}", status_code=204)
 async def delete_item(item_id: int):
     # ... delete the item ...
     return Response(status_code=204)

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -1065,7 +1065,7 @@ class SchemaGenerator:
             else:
                 # Opaque JSON: nothing to type. Recorded for strict mode.
                 self._opaque_operations.append(f"{method} {path}")
-                responses["200"] = OpenAPIResponse(
+                responses[str(default_status)] = OpenAPIResponse(
                     description="Successful response",
                     content={
                         "application/json": OpenAPIMediaType(schema=Schema(type="object")),

--- a/python/tests/test_openapi_default_status.py
+++ b/python/tests/test_openapi_default_status.py
@@ -1,0 +1,29 @@
+"""Check documented status codes for handlers without response annotations."""
+
+from __future__ import annotations
+
+import pytest
+
+from django_bolt import BoltAPI, Response
+from django_bolt.testing import TestClient
+
+
+@pytest.mark.parametrize("status_code", [200, 201, 202, 204])
+def test_unannotated_handler_documents_default_status_code(status_code):
+    api = BoltAPI()
+
+    @api.get("/result", status_code=status_code)
+    async def result():
+        if status_code == 204:
+            return Response(status_code=204)
+        return {"message": "Success"}
+
+    api._register_openapi_routes()
+    with TestClient(api) as client:
+        response = client.get("/result")
+        assert response.status_code == status_code
+        schema_response = client.get("/docs/openapi.json")
+        assert schema_response.status_code == 200
+
+    responses = schema_response.json()["paths"]["/result"]["get"]["responses"]
+    assert set(responses) == {str(status_code)}


### PR DESCRIPTION
OpenAPI used a hardcoded `200` for handlers without response annotations, even when the route declared another `status_code`. Use the configured status code so Swagger UI documents responses such as `201`, `202`, and `204` correctly. Add regression tests and clarify the response documentation.

Fixes #326

## How was this tested?

- Regression tests fail for `201`, `202`, and `204` before the fix and when the fix is temporarily reverted.
- Selected OpenAPI tests: 102 passed.
- Library lint and formatting checks passed.
- Full Python suite: 2,727 passed, 7 skipped, and 3 failures caused by the test invocation. Those failures passed in a 23-test rerun with the virtualenv on `PATH` and the `pytest` entry point.
- No Rust changes.

## Performance consideration

This change only affects OpenAPI schema generation. Request dispatch and serialization are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Hot request path

The PR does not touch the hot request path.

The change is limited to OpenAPI schema generation. It changes the documented response key from hardcoded `"200"` to the route’s configured status code.

This work runs during schema generation, not during request dispatch. Request dispatch and response serialization remain unchanged.

The change adds no per-request work. It is required to document configured statuses such as `201`, `202`, and `204` correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->