### PR TITLE
Fix OpenAPI JSON rendering and Debug Toolbar on docs

### DIFF
--- a/docs/src/topics/debug-toolbar.md
+++ b/docs/src/topics/debug-toolbar.md
@@ -90,6 +90,16 @@ Pages inside `api.mount_django("/django")` do not need this. Their toolbar calls
 
 **Why a list, not `True`:** `django_middleware=True` runs all of `settings.MIDDLEWARE` on Bolt routes. That includes `CsrfViewMiddleware`, which rejects API `POST` requests with `403`. The list runs only the toolbar. See [Middleware](middleware.md#django-middleware-integration) for the per-request cost.
 
+## API documentation
+
+The same middleware runs on the API documentation routes.
+When `runbolt` combines APIs, docs use the middleware from the API that supplies the OpenAPI configuration.
+With the setup above, Scalar (`/docs`) and Swagger (`/docs/swagger`) can show the toolbar.
+The JSON schema response cannot contain toolbar HTML.
+
+Custom HTML render plugins must include a closing `</body>` tag.
+The toolbar inserts its HTML before that tag.
+
 ## Static files
 
 The toolbar ships its CSS and JS as app static files. In `DEBUG`, Bolt serves them through Django's staticfiles finders. No extra setup is needed. See [Static Files](static-files.md).

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -2861,13 +2861,13 @@ class BoltAPI:
 
         return self._openapi_schema
 
-    def _register_openapi_routes(self) -> None:
+    def _register_openapi_routes(self, *, middleware: list[Any] | None = None) -> None:
         """Register OpenAPI documentation routes.
 
         Delegates to OpenAPIRouteRegistrar for cleaner separation of concerns.
         """
 
-        registrar = OpenAPIRouteRegistrar(self)
+        registrar = OpenAPIRouteRegistrar(self, middleware=middleware)
         registrar.register_routes()
 
     def _register_admin_routes(self, host: str = "localhost", port: int = 8000) -> None:

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -765,7 +765,7 @@ class Command(BaseCommand):
                 openapi_config = api._openapi_config
                 if openapi_config.enabled:
                     merged_api._openapi_config = openapi_config
-                    merged_api._register_openapi_routes()
+                    merged_api._register_openapi_routes(middleware=api._middleware if merged_api is not api else None)
                     features.append(("Docs", f"{banner_base_url}{openapi_config.path}"))
                 break
 
@@ -870,7 +870,7 @@ class Command(BaseCommand):
         if openapi_enabled and openapi_config:
             # Transfer OpenAPI config to merged API
             merged_api._openapi_config = openapi_config
-            merged_api._register_openapi_routes()
+            merged_api._register_openapi_routes(middleware=api._middleware if merged_api is not api else None)
             features.append(("Docs", f"{banner_base_url}{openapi_config.path}"))
 
         # Register Django admin routes if not disabled

--- a/python/django_bolt/openapi/plugins.py
+++ b/python/django_bolt/openapi/plugins.py
@@ -67,7 +67,7 @@ class OpenAPIRenderPlugin(ABC):
         return _json.encode(openapi_schema).decode("utf-8")
 
     @abstractmethod
-    def render(self, openapi_schema: dict[str, Any], schema_url: str) -> str:
+    def render(self, openapi_schema: dict[str, Any], schema_url: str) -> str | dict[str, Any]:
         """Render the OpenAPI UI.
 
         Args:
@@ -75,7 +75,7 @@ class OpenAPIRenderPlugin(ABC):
             schema_url: URL to the OpenAPI JSON schema.
 
         Returns:
-            The rendered HTML or data as string.
+            The rendered text or schema dictionary.
         """
         raise NotImplementedError
 
@@ -311,6 +311,7 @@ class ScalarRenderPlugin(OpenAPIRenderPlugin):
                 """
 
         body = f"""
+              <body>
                 <noscript>
                     Scalar requires Javascript to function. Please enable it to browse the documentation.
                 </noscript>
@@ -320,6 +321,7 @@ class ScalarRenderPlugin(OpenAPIRenderPlugin):
                 </script>
                 {options_script}
                 <script src="{self.js_url}" crossorigin></script>
+              </body>
                 """
 
         return f"""

--- a/python/django_bolt/openapi/routes.py
+++ b/python/django_bolt/openapi/routes.py
@@ -22,13 +22,14 @@ if TYPE_CHECKING:
 class OpenAPIRouteRegistrar:
     """Handles registration of OpenAPI documentation routes."""
 
-    def __init__(self, api: BoltAPI):
+    def __init__(self, api: BoltAPI, *, middleware: list[Any] | None = None):
         """Initialize the registrar with a BoltAPI instance.
 
         Args:
             api: The BoltAPI instance to register routes on
         """
         self.api = api
+        self._middleware = middleware
         self._docs_api = None  # Separate API for docs when using django_auth
 
     def _get_django_auth_decorator(self):
@@ -100,6 +101,9 @@ class OpenAPIRouteRegistrar:
 
         # Get the API to register routes on (separate API if using django_auth)
         docs_api = self._get_docs_api()
+        if docs_api is not self.api:
+            # Authenticated docs already run the Django middleware stack.
+            self._middleware = None
         use_django_auth = self.api._openapi_config.django_auth is not None
 
         # Get guards and auth from config for protecting doc routes
@@ -129,7 +133,12 @@ class OpenAPIRouteRegistrar:
 
         openapi_json_handler = self._apply_django_auth(openapi_json_handler)
         docs_api._route_decorator(
-            "GET", f"{route_prefix}/openapi.json", guards=guards, auth=auth, _skip_prefix=skip_prefix
+            "GET",
+            f"{route_prefix}/openapi.json",
+            guards=guards,
+            auth=auth,
+            _skip_prefix=skip_prefix,
+            _router_middleware=self._middleware,
         )(openapi_json_handler)
 
         # Always register YAML endpoints
@@ -143,7 +152,12 @@ class OpenAPIRouteRegistrar:
 
         openapi_yaml_handler = self._apply_django_auth(openapi_yaml_handler)
         docs_api._route_decorator(
-            "GET", f"{route_prefix}/openapi.yaml", guards=guards, auth=auth, _skip_prefix=skip_prefix
+            "GET",
+            f"{route_prefix}/openapi.yaml",
+            guards=guards,
+            auth=auth,
+            _skip_prefix=skip_prefix,
+            _router_middleware=self._middleware,
         )(openapi_yaml_handler)
 
         async def openapi_yml_handler(request):
@@ -154,7 +168,12 @@ class OpenAPIRouteRegistrar:
 
         openapi_yml_handler = self._apply_django_auth(openapi_yml_handler)
         docs_api._route_decorator(
-            "GET", f"{route_prefix}/openapi.yml", guards=guards, auth=auth, _skip_prefix=skip_prefix
+            "GET",
+            f"{route_prefix}/openapi.yml",
+            guards=guards,
+            auth=auth,
+            _skip_prefix=skip_prefix,
+            _router_middleware=self._middleware,
         )(openapi_yml_handler)
 
         # Register UI plugin routes
@@ -195,12 +214,20 @@ class OpenAPIRouteRegistrar:
 
                 # Create closure to capture plugin reference
                 def make_handler(p):
+                    response_class = (
+                        JSON
+                        if isinstance(p, JsonRenderPlugin)
+                        else PlainText
+                        if isinstance(p, YamlRenderPlugin)
+                        else HTML
+                    )
+
                     async def ui_handler(request):
                         """Serve OpenAPI UI."""
                         try:
                             schema = self._get_schema()
                             rendered = p.render(schema, schema_url)
-                            return HTML(rendered, status_code=200, headers={"content-type": p.media_type})
+                            return response_class(rendered, status_code=200, headers={"content-type": p.media_type})
                         except Exception as e:
                             raise Exception(
                                 f"Failed to render OpenAPI UI plugin {p.__class__.__name__}: "
@@ -211,7 +238,14 @@ class OpenAPIRouteRegistrar:
 
                 handler = make_handler(plugin)
                 handler = self._apply_django_auth(handler)
-                docs_api._route_decorator("GET", full_path, guards=guards, auth=auth, _skip_prefix=skip_prefix)(handler)
+                docs_api._route_decorator(
+                    "GET",
+                    full_path,
+                    guards=guards,
+                    auth=auth,
+                    _skip_prefix=skip_prefix,
+                    _router_middleware=self._middleware,
+                )(handler)
 
     def _register_root_redirect(self, docs_api, route_prefix: str, skip_prefix: bool) -> None:
         """Register root path to serve default UI directly.
@@ -235,12 +269,16 @@ class OpenAPIRouteRegistrar:
 
             # Capture plugin in closure
             def make_root_handler(p, url):
+                response_class = (
+                    JSON if isinstance(p, JsonRenderPlugin) else PlainText if isinstance(p, YamlRenderPlugin) else HTML
+                )
+
                 async def openapi_root_handler(request):
                     """Serve default OpenAPI UI at root path."""
                     try:
                         schema = self._get_schema()
                         rendered = p.render(schema, url)
-                        return HTML(rendered, status_code=200, headers={"content-type": p.media_type})
+                        return response_class(rendered, status_code=200, headers={"content-type": p.media_type})
                     except Exception as e:
                         raise Exception(f"Failed to render OpenAPI UI: {type(e).__name__}: {str(e)}") from e
 
@@ -248,4 +286,11 @@ class OpenAPIRouteRegistrar:
 
             handler = make_root_handler(plugin, schema_url)
             handler = self._apply_django_auth(handler)
-            docs_api._route_decorator("GET", root_path, guards=guards, auth=auth, _skip_prefix=skip_prefix)(handler)
+            docs_api._route_decorator(
+                "GET",
+                root_path,
+                guards=guards,
+                auth=auth,
+                _skip_prefix=skip_prefix,
+                _router_middleware=self._middleware,
+            )(handler)

--- a/python/tests/integration/apps/docs_middleware.py
+++ b/python/tests/integration/apps/docs_middleware.py
@@ -1,0 +1,22 @@
+"""Multiple APIs with Django middleware on the documentation owner."""
+
+from django_bolt import BoltAPI
+from django_bolt.openapi import OpenAPIConfig, SwaggerRenderPlugin
+
+api = BoltAPI(
+    django_middleware=["debug_toolbar.middleware.DebugToolbarMiddleware"],
+    openapi_config=OpenAPIConfig(title="Merged docs", version="1", render_plugins=[SwaggerRenderPlugin()]),
+)
+
+
+@api.get("/health")
+async def health():
+    return {"ok": True}
+
+
+other_api = BoltAPI()
+
+
+@other_api.get("/other/health")
+async def other_health():
+    return {"ok": True}

--- a/python/tests/integration/test_docs_middleware.py
+++ b/python/tests/integration/test_docs_middleware.py
@@ -1,0 +1,36 @@
+"""Test documentation middleware after runbolt merges multiple APIs."""
+
+import httpx
+import pytest
+
+from .apps import app_module
+
+
+@pytest.mark.server_integration
+def test_merged_docs_debug_toolbar(make_server_project):
+    pytest.importorskip("debug_toolbar")
+    module = app_module("docs_middleware").split(":")[0]
+    project = make_server_project(
+        api_module=f"{module}:api",
+        installed_apps=["django.contrib.staticfiles", "debug_toolbar"],
+        urls_content='from django.urls import include, path\nurlpatterns = [path("__debug__/", include("debug_toolbar.urls"))]\n',
+        templates=[{"BACKEND": "django.template.backends.django.DjangoTemplates", "APP_DIRS": True}],
+        settings_extra=f'''
+BOLT_API = ["{module}:api", "{module}:other_api"]
+INTERNAL_IPS = ["127.0.0.1"]
+STATIC_URL = "/static/"
+DEBUG_TOOLBAR_PANELS = ["debug_toolbar.panels.timer.TimerPanel"]
+DEBUG_TOOLBAR_CONFIG = {{"RENDER_PANELS": True}}
+''',
+    )
+    with project.start() as server:
+        for route in ["/docs", "/docs/swagger"]:
+            response = httpx.get(f"{server.base_url}{route}")
+            assert response.status_code == 200, response.text
+            assert 'id="djDebug"' in response.text
+        response = httpx.get(f"{server.base_url}/docs/openapi.json")
+        assert "/other/health" in response.json()["paths"]
+        assert "Server-Timing" in response.headers
+        response = httpx.get(f"{server.base_url}/other/health")
+        assert response.status_code == 200
+        assert "Server-Timing" not in response.headers

--- a/python/tests/test_openapi_render_middleware.py
+++ b/python/tests/test_openapi_render_middleware.py
@@ -1,0 +1,77 @@
+"""Regression tests for schema rendering and Django middleware on docs."""
+
+import sys
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+from django.urls import include, path
+
+from django_bolt import BoltAPI
+from django_bolt.openapi import (
+    JsonRenderPlugin,
+    OpenAPIConfig,
+    ScalarRenderPlugin,
+    SwaggerRenderPlugin,
+    YamlRenderPlugin,
+)
+from django_bolt.testing import TestClient
+
+
+@pytest.mark.parametrize("plugin_path", ["/openapi.json", "/schema.json"])
+def test_explicit_json_plugin(plugin_path):
+    api = BoltAPI(
+        openapi_config=OpenAPIConfig(
+            title="Explicit JSON", version="1", render_plugins=[JsonRenderPlugin(path=plugin_path)]
+        )
+    )
+    api._register_openapi_routes()
+    with TestClient(api) as client:
+        for url in ["/docs", f"/docs{plugin_path}", "/docs/openapi.json"]:
+            response = client.get(url)
+            assert response.status_code == 200, response.text
+            assert response.headers["content-type"] == "application/vnd.oai.openapi+json"
+            assert response.json()["info"]["title"] == "Explicit JSON"
+
+
+def test_explicit_yaml_plugin():
+    api = BoltAPI(openapi_config=OpenAPIConfig(title="YAML", version="1", render_plugins=[YamlRenderPlugin()]))
+    api._register_openapi_routes()
+    with TestClient(api) as client:
+        for url in ["/docs", "/docs/openapi.yaml", "/docs/openapi.yml"]:
+            response = client.get(url)
+            assert response.status_code == 200, response.text
+            assert response.headers["content-type"] == "text/yaml; charset=utf-8"
+            assert "title: YAML" in response.text
+
+
+@pytest.mark.parametrize("plugin", [ScalarRenderPlugin(), SwaggerRenderPlugin()])
+def test_debug_toolbar_in_docs(plugin, monkeypatch):
+    pytest.importorskip("debug_toolbar")
+    with override_settings(
+        INSTALLED_APPS=[*settings.INSTALLED_APPS, "debug_toolbar"],
+        ROOT_URLCONF=__name__,
+        DEBUG_TOOLBAR_PANELS=["debug_toolbar.panels.timer.TimerPanel"],
+        DEBUG_TOOLBAR_CONFIG={"SHOW_TOOLBAR_CALLBACK": lambda _request: True, "RENDER_PANELS": True},
+    ):
+        monkeypatch.setattr(
+            sys.modules[__name__],
+            "urlpatterns",
+            [path("__debug__/", include("debug_toolbar.urls"))],
+            raising=False,
+        )
+        api = BoltAPI(
+            django_middleware=["debug_toolbar.middleware.DebugToolbarMiddleware"],
+            openapi_config=OpenAPIConfig(title="Toolbar", version="1", render_plugins=[plugin]),
+        )
+        api._register_openapi_routes()
+        with TestClient(api) as client:
+            for url in ["/docs", f"/docs{plugin.paths[0]}"]:
+                response = client.get(url)
+                assert response.status_code == 200, response.text
+                assert 'id="djDebug"' in response.text
+                assert response.text.index('id="djDebug"') < response.text.lower().rindex("</body>")
+            response = client.get("/docs/openapi.json")
+            assert response.status_code == 200
+            assert response.json()["info"]["title"] == "Toolbar"
+            assert 'id="djDebug"' not in response.text


### PR DESCRIPTION
Explicit `JsonRenderPlugin` routes returned 500 because the docs handler wrapped schema dictionaries in `HTML`. Select the JSON response class for these plugins, preserve the docs owner's middleware when `runbolt` combines APIs, and add Scalar body tags so Django Debug Toolbar can insert its HTML.

Docs now retain the configured middleware without applying it to unrelated APIs. Add regression tests and document toolbar support on docs pages.

## How was this tested?

- 80 tests passed across OpenAPI docs, rendering, Django middleware, and the new real-server regression test.
- Library lint and changed test lint passed; `git diff --check` passed.
- Confirmed regression tests fail when the fixes are removed and pass when restored.
- Checked the running example's `/docs`: toolbar HTML and response headers are present; toolbar CSS and JavaScript return 200.
- The full Python suite was not run. No Rust changes.

## Performance consideration

Response class selection and middleware configuration happen during route registration. Existing middleware dispatch handles docs requests. Unrelated API routes retain their original middleware.
