### PR TITLE
fix: skip import of docs_middleware app fixture in smoke test

### DIFF
--- a/python/tests/integration/test_apps_smoke.py
+++ b/python/tests/integration/test_apps_smoke.py
@@ -25,8 +25,10 @@ _MODULE_NAMES = sorted(info.name for info in pkgutil.iter_modules(apps.__path__)
 
 # App fixtures that only import inside the temp project a subprocess test
 # builds: ``reload_import_dep`` imports a sibling top-level ``reload_helper``
-# module that exists only there. They get a syntax check instead.
-_PROJECT_ONLY_MODULES = ["reload_import_dep"]
+# module that exists only there, and ``docs_middleware`` makes a ``BoltAPI``
+# with ``debug_toolbar`` middleware, which needs ``debug_toolbar`` in
+# ``INSTALLED_APPS``. They get a syntax check instead.
+_PROJECT_ONLY_MODULES = ["docs_middleware", "reload_import_dep"]
 _IMPORTABLE_MODULE_NAMES = [name for name in _MODULE_NAMES if name not in _PROJECT_ONLY_MODULES]
 
 


### PR DESCRIPTION
## Problem

Every `Test Python x / Django y` job in the v0.11.1 CI run failed on one test:

```
FAILED python/tests/integration/test_apps_smoke.py::test_app_module_exposes_populated_api[docs_middleware]
RuntimeError: Model class debug_toolbar.models.HistoryEntry doesn't declare an
explicit app_label and isn't in an application in INSTALLED_APPS.
```

`apps/docs_middleware.py` makes a `BoltAPI` with `debug_toolbar` middleware at import time. django-debug-toolbar 7.1.1 defines a model, so that import needs `debug_toolbar` in `INSTALLED_APPS`. The default test settings do not have it. Only the temp project that the subprocess test builds installs it.

## Fix

Add the fixture to `_PROJECT_ONLY_MODULES`, the existing list for fixtures that import only inside the temp project. It gets a syntax check instead.

`python/tests/integration/test_apps_smoke.py`: 45 passed. `test_docs_middleware.py` is unchanged and still covers the fixture.

https://claude.ai/code/session_01RNKDaunFGKX3DjJ9KwV9v6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The PR does not touch the production hot request path.

It changes only `python/tests/integration/test_apps_smoke.py`. The change prevents `docs_middleware` from being imported during the smoke test and applies a syntax check instead. No runtime request handling or middleware execution changes. No hot-path performance impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->